### PR TITLE
Updates from the Spring 2015 semester at ELTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Usage
 
 An online HTML version can be found at
 
-http://people.inf.elte.hu/divip/AgdaTutorial/Index.html
+http://people.inf.elte.hu/pgj/agda/tutorial/
 
 
 Local Builds

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -2,7 +2,7 @@
 DOTS=$(wildcard dot/*.dot)
 DOTPNG=$(patsubst dot/%.dot, html/dot/%.gif, $(DOTS))
 
-.PHONY: html sync clean
+.PHONY: html clean
 
 html: $(DOTPNG)
 	agdapandoc -i ~/share/Agda/lib/src/ -i src --html=NoSlides src/Index.lagda --css=Agda.css

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -1,15 +1,14 @@
 
 DOTS=$(wildcard dot/*.dot)
 DOTPNG=$(patsubst dot/%.dot, html/dot/%.gif, $(DOTS))
+AGDAPANDOC?=agdapandoc
+AGDASTDLIB?=~/share/Agda/lib
+HTMLFLAGS?=--html
 
 .PHONY: html clean
 
 html: $(DOTPNG)
-	agdapandoc -i ~/share/Agda/lib/src/ -i src --html=NoSlides src/Index.lagda --css=Agda.css
-#	agda -i ~/share/Agda/lib/src/ -i . --html=SlidySlides --template=slidy.template Index.lagda --css=Agda.css
-#	agda -i ~/share/Agda/lib/src/ -i . --html=S5Slides --template=s5.template Index.lagda --css=Agda.css
-#	agda -i ~/share/Agda/lib/src/ -i . --html=DZSlides --template=dz.template Index.lagda --css=Agda.css
-#	agda -i ~/share/Agda/lib/src/ -i . --html=SlideousSlides --template=slideous.template Index.lagda --css=Agda.css
+	$(AGDAPANDOC) -i $(AGDASTDLIB)/src/ -i src $(HTMLFLAGS) src/Index.lagda --css=Agda.css
 
 clean:
 	find . -name "*.agdai" -exec rm -f {} \; 

--- a/tutorial/src/About.lagda
+++ b/tutorial/src/About.lagda
@@ -22,7 +22,7 @@ Assumptions
 -   Theoretical remarks interrupt the programming experience.
     *   Students react quite differently to theoretical remarks.  
         (confused ↔ want to know a lot more)
--   People who already played with Agda are more
+-   People who have already played with Agda are more
     open to theoretical background.  
 
 
@@ -31,67 +31,70 @@ Goal details
 
 **Subgoals**
 :   -   give the syntax and semantics of Agda by examples
-    -   teach Agda programming skills
+:   -   teach Agda programming skills
+
 **Requirements**
-:   * Only secondary school mathematics is required.
-    * Haskell, type theory and category theory knowledge is **not** required.
+:   -   only secondary school mathematics is required
+:   -   Haskell, type theory, and category theory knowledge is **not** required
+
 **Audience**
-:   - for newcomers
-    - followable without a tutor
+:   -   for newcomers
+:   -   followable even without a tutor
 
 
 How to teach programming skills
 ============
 
--   The programmers should know equivalent solutions to be able to make design decisions.  
-    We teach program transformations steps.
--   The programmers should know which solution is better to be able to make design decisions.  
-    We add remarks to each program transformation steps.
+-   Programmers should know equivalent solutions to be able to make design decisions.  
+    *Hence we teach program transformations steps.*
+
+-   Programmers should know which solution is better to be able to make design decisions.  
+    *Hence we add remarks to each program transformation step.*
+
 -   We teach how to do incremental program construction (planned).
 
 
 Additional features
 ======
 
--   teach data types first, functions later
+-   Teach data types first, functions later
 
 
 
 
-Darcs repository
+GitHub repository
 ============
 
-The darcs repository is located at
+There is a [git](http://git-scm.com/) repository located at [GitHub](https://github.com/):
 
-[http://hub.darcs.net/divip/AgdaTutorial](http://hub.darcs.net/divip/AgdaTutorial)
+[https://github.com/mcmtroffaes/AgdaTutorial](https://github.com/mcmtroffaes/AgdaTutorial)
 
-You are welcome to send patches (please send small patches first)!
+You are welcome to submit pull requests (but please make small changes first)!
 
 
 Social contract
 ===============
 
--   remain freely available and ready to fork
--   give citation of sources if applicable
--   try to merge with similar tutorials if any
+-   Remain freely available and ready to fork
+-   Give citation of sources if applicable
+-   Try to merge with similar tutorials if any
 
 
 Users
 =========
 
-This is the 5th semester we teach Agda at ELTE Budapest with the help of
-this tutorial.
+This is the 6th semester we teach Agda at Eötvös Loránd University (ELTE)
+with the help of this tutorial.
 
--   13 week × 90 min
--   Lecturers: Péter Diviánszky and Ambrus Kaposi
-    *   we also learn a lot by teaching Agda
+-   13 weeks × 90 mins.
+-   Lecturer: Gábor Páli
+-   Past lecturers: Péter Diviánszky, Ambrus Kaposi
+-   We also learn a lot by teaching Agda :-)
 
 
-Other material
+Further materials
 ========
 
 \begin{code}
 import About.AIM_XVI     -- The original slides for AIM XVI.
 \end{code}
-
-

--- a/tutorial/src/Application/Algebra.lagda
+++ b/tutorial/src/Application/Algebra.lagda
@@ -22,7 +22,7 @@ We can model the semigroup proposition as follows:
 \begin{code}
 record IsSemigroup {A : Set} (_∙_ : A → A → A) : Set where
   field
-    assoc         : ∀ x y z →  (x ∙ y) ∙ z  ≡  x ∙ (y ∙ z)
+    assoc         : ∀ x y z →  ((x ∙ y) ∙ z)  ≡  (x ∙ (y ∙ z))
 \end{code}
 
 
@@ -91,7 +91,7 @@ Monoid property
 record IsMonoid {A : Set} (_∙_ : A → A → A) (ε : A) : Set where
   field
     isSemigroup : IsSemigroup _∙_
-    identity    : (∀ x → ε ∙ x ≡ x)  ×  (∀ x → x ∙ ε ≡ x)
+    identity    : (∀ x → (ε ∙ x) ≡ x)  ×  (∀ x → (x ∙ ε) ≡ x)
 
   open IsSemigroup isSemigroup public
 \end{code}
@@ -157,7 +157,7 @@ Thus we can write
 \begin{code}
 record IsSemigroup′ {A : Set} (_∙_ : Op₂ A) : Set where
   field
-    assoc         : ∀ x y z →  (x ∙ y) ∙ z  ≡  x ∙ (y ∙ z)
+    assoc         : ∀ x y z →  ((x ∙ y) ∙ z)  ≡  (x ∙ (y ∙ z))
 \end{code}
 
 
@@ -181,7 +181,7 @@ We can name functions properties like
 
 \begin{code}
 Associative : {A : Set} → Op₂ A → Set
-Associative _∙_ = ∀ x y z →  (x ∙ y) ∙ z  ≡  x ∙ (y ∙ z)
+Associative _∙_ = ∀ x y z →  ((x ∙ y) ∙ z)  ≡  (x ∙ (y ∙ z))
 \end{code}
 
 After this definition we can write
@@ -204,7 +204,7 @@ Commutative : {A : Set} → Op₂ A → Set _
 
 <!--
 \begin{code}
-Commutative _∙_ = ∀ x y →  x ∙ y  ≡  y ∙ x
+Commutative _∙_ = ∀ x y →  (x ∙ y)  ≡  (y ∙ x)
 \end{code}
 -->
 
@@ -216,7 +216,7 @@ LeftIdentity : {A : Set} → A → Op₂ A → Set _
 
 <!--
 \begin{code}
-LeftIdentity e _∙_ = ∀ x →  e ∙ x  ≡  x
+LeftIdentity e _∙_ = ∀ x →  (e ∙ x)  ≡  x
 \end{code}
 -->
 
@@ -226,7 +226,7 @@ RightIdentity : {A : Set} → A → Op₂ A → Set _
 
 <!--
 \begin{code}
-RightIdentity e _∙_ = ∀ x →  x ∙ e  ≡  x
+RightIdentity e _∙_ = ∀ x →  (x ∙ e)  ≡  x
 \end{code}
 -->
 

--- a/tutorial/src/Constants.lagda
+++ b/tutorial/src/Constants.lagda
@@ -1,13 +1,13 @@
 % Constant Definitions
 
-Import List
+Import list
 ===========
 
 \begin{code}
 module Constants where
 
-open import Data.Bool using (Bool; true; false)
-open import Data.Nat using (ℕ; zero; suc)
+open import Sets.Enumerated using (Bool; true; false)
+open import Sets.Recursive using (ℕ; zero; suc)
 \end{code}
 
 
@@ -35,9 +35,10 @@ Normal form
 =======================
 
 `ten`, `suc nine` and `suc (suc (suc (suc (suc (suc (suc (suc (suc zero))))))))` equally
-represent the number 10, but only the last one is the so called *normal form*.
+represent the number 10, but only the last one is the so-called *normal form*.
 
-One can ask for the normal form in the interactive environment by C-`c` C-`n`.
+One can ask for the normal form of an expression in the interactive environment
+by C-`c` C-`n`.
 
 
 

--- a/tutorial/src/Emacs_Usage.lagda
+++ b/tutorial/src/Emacs_Usage.lagda
@@ -60,7 +60,8 @@ M-`.`             jump to definition
 M-`*`             jump back
 ----------------- -----------------------------------------
 
-See also the `Agda` menu on the menu bar
+Note that you can also find the same (and further more) commands in the
+`Agda` submenu on the menu bar.
 
 
 Commands inside a hole
@@ -75,10 +76,10 @@ C-`c` C-`r`       refine (one step further)
 C-`c` C-`a`       auto (try to find a solution)
 ----------------- -----------------------------------------
 
-See also the context-sensitive menu when right-clicking inside a hole
+See also the context-sensitive menu on the right click inside a hole.
 
 
-Emacs Agda-mode unicode symbols
+Emacs Agda-mode Unicode symbols
 ===========================
 
 ----------------------- -------------------

--- a/tutorial/src/Functions/Cases.lagda
+++ b/tutorial/src/Functions/Cases.lagda
@@ -3,12 +3,12 @@
 \begin{code}
 module Functions.Cases where
 
-open import Data.Bool using (Bool; true; false)
+open import Sets.Enumerated using (Bool; true; false)
 \end{code}
 
 
 Negation as a function
-============================
+======================
 
 Representation of negation as a function from `Bool` to `Bool`:
 
@@ -18,32 +18,35 @@ not true  = false
 not false = true
 \end{code}
 
-We pattern match on the elements that appear in set `Bool` namely `true` and `false` to define how the function works.
+We pattern match on the elements that appear in the `Bool` set
+&mdash; that is `true` and `false` &mdash; in order to define how the
+function works.
 
 
 Computational content of functions
 ==================================
 
-We have elements of `Bool` like
+Now we have got elements of `Bool` like as follows:
 
 `not true : Bool`  
 `not (not (not false)) : Bool`  
 
-but these are not new elements: their normal form is either `true` or `false`.
+Note that these are not new elements: their normal form is still either `true`
+or `false`.  In the interactive environment, we can compute those normal forms
+by the C-`c` C-`n` key combination.
 
-In the interactive environment we can compute the normal form by C-`c` C-`n`.
-
-Functions have *computational content*.  
-For example, `not` defines not just a relation between `Bool` and `Bool`,
-but also an algorithm how to compute the negated value.
+The reason is that functions have a certain *computational content*.  For
+example, `not` defines not only a relation between `Bool` and `Bool`, but it
+also presents an algorithm on how to compute the negated value.
 
 
-Logical AND
-===============================
+Logical conjunction
+===================
 
-Logical AND could be defined with four alternatives but
-here is a shorter definition with two alternatives with variables:
- 
+The logical conjunction could be defined with pattern matching on all the
+possible four alternatives (that is, as a table), but here is a shorter
+definition with only two alternatives and with variables:
+
 \begin{code}
 _∧_   : Bool → Bool → Bool
 true  ∧ x = x
@@ -52,35 +55,57 @@ false ∧ _ = false
 infixr 6 _∧_
 \end{code}
 
+Note the following:
 
 -   We can use variables as patterns.
--   We can use wildcard (an underscore) as a pattern.  
-    A wildcard pattern is an unnamed variable.
--   Similar to data sets
-    -   Underscores in names like `_∧_` denote the space for the operands.
-    -   `infixr` gives the fixity
+
+-   We can use wildcards (underscores) as patterns.  A wildcard pattern can
+    also be considered as an unnamed variable.
+
+-   Similarly to data sets:
+
+    -   Underscores in names &mdash; such as `_∧_` &mdash; denote the space for
+        the operands.
+
+    -   The `infixr` keyword gives the associativity and precedence.
 
 
-Exercise: `_∨_`
-=========
+Exercises
+---------
 
+1. Define the logical disjunction as a function.
 
-A) Define logical OR:
+     `infixr 5 _∨_`  
+     `_∨_   : Bool → Bool → Bool`
+
+1. Redefine the logical disjunction in a single line, with the help of `not`
+   and `_∧_` functions.
+
+1. Define a set named `Answer` with three elements: `yes`, `no`, and `maybe`.
+   Define the logical conjunction and disjunction operations on `Answer`.
+
+1. Define a set named `Quarter` with four elements: `east`, `west`, `north`,
+   and `south`.  Define the `turnLeft` function with the following type:
+
+     `turnLeft : Quarter → Quarter`
+
+1. For the previous exercise, define the `turnBack` and `turnRight` functions
+   with the help of `turnLeft`.
+
+     `turnRight : Quarter → Quarter`  
+     `turnBack  : Quarter → Quarter`
+
+     (This can be done with either pattern matching or defining the function
+     composition (`_∘_`) and using it.)
+
 
 \begin{code}
 infixr 5 _∨_
- 
-_∨_   : Bool → Bool → Bool
-\end{code}
 
-<!--
-\begin{code}
+_∨_   : Bool → Bool → Bool
 true  ∨ _ = true --
 false ∨ x = x --
 \end{code}
--->
- 
-B) Define logical OR with one alternative, with the help of `not` and `_∧_`!
 
 <!--
 \begin{code}
@@ -90,20 +115,3 @@ _∨₁_   : Bool → Bool → Bool --
 x ∨₁ y = not (not x ∧ not y) --
 \end{code}
 -->
- 
-Exercises
-=========
-
-A)  Define a set named `Answer` with three elements, `yes`, `no` and `maybe`.
-
-    Define logical operations on `Answer`!
- 
-B)  Define a set named `Quarter` with four elements, `east`, `west`, `north` and `south`.
-
-    Define a function `turnLeft : Quarter → Quarter`.
- 
-    Define the functions `turnBack` and `turnRight` with the help of `turnLeft`! (By either pattern matching or defining a specific function composition function.)
-
-
-
-

--- a/tutorial/src/Functions/Dependent.lagda
+++ b/tutorial/src/Functions/Dependent.lagda
@@ -1,5 +1,7 @@
 % Dependently Typed Functions
 
+Import list
+===========
 
 \begin{code}
 module Functions.Dependent where
@@ -12,216 +14,149 @@ open import Data.Product using (_×_; _,_)
 
 
 Dependently typed functions
-===============
+===========================
 
-Dependently typed function:
+We call the function `f : (x : A) → B` dependently-typed
+if `B` (set) may depend on `x` (value).
 
-`f : (x : A) → B`, where `B` may depend on `x`
-
-*Example*  
+For example, consider the following:
 
 \begin{code}
 fromℕ : (n : ℕ) → Fin (suc n)
-fromℕ zero = zero  -- Note: different zeros
+fromℕ zero    = zero            -- Note: this is a different zero!
 fromℕ (suc n) = suc (fromℕ n)
 \end{code}
 
-*Notes*
+*Remarks:*
 
--   The dependent function spaces are called `Π`-types because
-    the number of elements can be given as a product:  
-    ∣`(x : A)→ B`∣ = ∏`x`∈`A` ∣`B`∣, for example  
-    ∣`(n : Fin m)→ Fin (suc n)`∣ = (`m` + 1)!
--   Polymorphic functions like `(A : Set) → A → A` are special cases of dependent functions.
--   Non-dependent functions like `A → B` are special cases of dependent functions  
-    (`(x : A) → B` where `B` doesn't depend on `x`).
+- The spaces of dependent functions are called `Π`-types because the number of
+  their elements could be given as a product, that is:
 
+    ∣ `(x : A) → B` ∣ = ∏(`x`∈`A`) ∣`B`∣
 
+    For example:
+
+    ∣ `(n : Fin m) → Fin (suc n)` ∣ = (`m` + 1)!
+
+-   Polymorphic functions, such as `(A : Set) → A → A` are special cases for
+    dependent functions.
+
+-   Non-dependent functions, such as `A → B` are only special cases for dependent
+    functions, that is:
+
+    `(x : A) → B` where `B` does not depend on `x`, so it is `A → B`
 
 
 Exercises
-=========
+---------
 
-Define a substraction with restricted domain:
+1. Define a subtraction with a restricted domain.
 
-\begin{code}
-_-_ : (n : ℕ) → Fin (suc n) → ℕ
-\end{code}
+     `_-_ : (n : ℕ) → Fin (suc n) → ℕ`
+
+1. Define a conversion from `Fin n` to `ℕ`.
+
+     `toℕ : ∀ {n} → Fin n → ℕ`
+
+1. Define `fromℕ≤` such that `toℕ (fromℕ≤ e)` is `m` if `e : m < n`.
+
+     `fromℕ≤ : ∀ {m n} → m < n → Fin n`
+
+1. Define `inject+` such that `toℕ (inject+ n i)` is the same as `toℕ i`.
+
+     `inject+ : ∀ {m} n → Fin m → Fin (m + n)`
+
+1. Define `four` such that `toℕ four` is `4`:
+
+     `four : Fin 66`
+
+1. Define `raise` such that `toℕ (raise n i)` is the same as `n + toℕ i`:
+
+     `raise : ∀ {m} n → Fin m → Fin (n + m)`
+
+1. Define (a safe, total version of) `head` and `tail`.
+
+     `head : ∀ {n}{A : Set} → Vec A (suc n) → A`  
+     `tail : ∀ {n}{A : Set} → Vec A (suc n) → Vec A n`
+
+1. Define concatenation for vectors.
+
+     `_++_ : ∀ {n m}{A : Set} → Vec A n → Vec A m → Vec A (n + m)`
+
+1. Define `maps`. (Note that two cases will be enough.)
+
+     `maps : ∀ {n}{A B : Set} → Vec (A → B) n → Vec A n → Vec B n`
+
+1. Define `replicate`.
+
+     `replicate : ∀ {n}{A : Set} → A → Vec A n`
+
+1. Define `map` with the help of `maps` and `replicate`.
+
+     `map : ∀ {n}{A B : Set} → (A → B) → Vec A n → Vec B n`
+
+1. Define `zip` with the help of `map` and `maps`.
+
+     `zip : ∀ {n}{A B : Set} → Vec A n → Vec B n → Vec (A × B) n`
+
+1. Define (safe, total) element indexing.
+
+     `_!_ : ∀ {n}{A : Set} → Vec A n → Fin n → A`
 
 <!--
 \begin{code}
+_-_ : (n : ℕ) → Fin (suc n) → ℕ
 zero - zero = zero
 zero - suc ()
 suc n - zero = suc n
 suc n - suc m = n - m
-\end{code}
--->
 
-Define `toℕ`:
-
-\begin{code}
 toℕ : ∀ {n} → Fin n → ℕ
-\end{code}
-
-<!--
-\begin{code}
 toℕ zero    = zero
 toℕ (suc n) = suc (toℕ n)
-\end{code}
--->
 
-Define `fromℕ≤` such that `toℕ (fromℕ≤ e)` is `m` if `e : m < n`:
-
-\begin{code}
 fromℕ≤ : ∀ {m n} → m < n → Fin n
-\end{code}
-
-<!--
-\begin{code}
 fromℕ≤ (s≤s z≤n)       = zero
 fromℕ≤ (s≤s (s≤s m≤n)) = suc (fromℕ≤ (s≤s m≤n))
-\end{code}
--->
 
-Define `inject+` such that `toℕ (inject+ n i)` is the same as `toℕ i`:
-
-\begin{code}
 inject+ : ∀ {m} n → Fin m → Fin (m + n)
-\end{code}
-
-<!--
-\begin{code}
 inject+ n zero    = zero
 inject+ n (suc i) = suc (inject+ n i)
-\end{code}
--->
 
-Define `four` such that `toℕ four` is `4`:
-
-\begin{code}
 four : Fin 66
-\end{code}
-
-<!--
-\begin{code}
 four = inject+ 61 (fromℕ 4)
-\end{code}
--->
 
-Define `raise` such that `toℕ (raise n i)` is the same as `n + toℕ i`:
-
-\begin{code}
 raise : ∀ {m} n → Fin m → Fin (n + m)
-\end{code}
-
-<!--
-\begin{code}
 raise zero i = i
 raise (suc n) i = suc (raise n i)
-\end{code}
--->
 
-
-
-Exercises
-=========
-
-Define `head` and `tail`.
-
-\begin{code}
 head : ∀ {n}{A : Set} → Vec A (suc n) → A
-\end{code}
-
-<!--
-\begin{code}
 head (a ∷ as) = a
-\end{code}
--->
 
-\begin{code}
 tail : ∀ {n}{A : Set} → Vec A (suc n) → Vec A n
-\end{code}
-
-<!--
-\begin{code}
 tail (a ∷ as) = as
-\end{code}
--->
 
-Define concatenation for vectors.
-
-\begin{code}
 _++_ : ∀ {n m}{A : Set} → Vec A n → Vec A m → Vec A (n + m)
-\end{code}
-
-<!--
-\begin{code}
 []       ++ bs = bs
 (a ∷ as) ++ bs = a ∷ (as ++ bs)
-\end{code}
--->
 
-Define `maps`. (Note that two cases will be enough!)
-
-\begin{code}
 maps : ∀ {n}{A B : Set} → Vec (A → B) n → Vec A n → Vec B n
-\end{code}
-
-<!--
-\begin{code}
 maps [] [] = []
 maps (f ∷ fs) (a ∷ as) = f a ∷ maps fs as
-\end{code}
--->
 
-Define `replicate`.
-
-\begin{code}
 replicate : ∀ {n}{A : Set} → A → Vec A n
-\end{code}
-
-<!--
-\begin{code}
 replicate {zero}  a = []
 replicate {suc n} a = a ∷ replicate a
-\end{code}
--->
 
-Define `map` with the help of `maps` and `replicate`.
-
-\begin{code}
 map : ∀ {n}{A B : Set} → (A → B) → Vec A n → Vec B n
-\end{code}
-
-<!--
-\begin{code}
 map f xs = maps (replicate f) xs
-\end{code}
--->
 
-Define `zip` with the help of `map` and `maps`.
-
-\begin{code}
 zip : ∀ {n}{A B : Set} → Vec A n → Vec B n → Vec (A × B) n
-\end{code}
-
-<!--
-\begin{code}
 zip as bs = maps (map (_,_) as) bs
-\end{code}
--->
 
-Define safe element indexing.
-
-\begin{code}
 _!_ : ∀ {n}{A : Set} → Vec A n → Fin n → A
-\end{code}
-
-<!--
-\begin{code}
 [] ! ()
 (a ∷ as) ! zero = a
 (a ∷ as) ! suc n = as ! n
 \end{code}
 -->
-

--- a/tutorial/src/Functions/Dependent.lagda
+++ b/tutorial/src/Functions/Dependent.lagda
@@ -157,7 +157,7 @@ _++_ : ∀ {n m}{A : Set} → Vec A n → Vec A m → Vec A (n + m)
 <!--
 \begin{code}
 []       ++ bs = bs
-(a ∷ as) ++ bs = a ∷ as ++ bs
+(a ∷ as) ++ bs = a ∷ (as ++ bs)
 \end{code}
 -->
 

--- a/tutorial/src/Functions/Equality_Proofs.lagda
+++ b/tutorial/src/Functions/Equality_Proofs.lagda
@@ -6,7 +6,7 @@
 module Functions.Equality_Proofs where
 \end{code}
 
-Import List
+Import list
 ===========
 
 \begin{code}
@@ -15,11 +15,11 @@ open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _≤_; z≤n; s≤s)
 open import Data.List using (List; []; _∷_; _++_)
 open import Data.Unit using (⊤; tt)
 open import Data.Product using (_×_; _,_)
-open import Function using (_$_)         -- 
+open import Function using (_$_)         --
 \end{code}
 
 Propositional equality: `_≡_`
-================
+=============================
 
 Recall the definition of propositional equality:
 
@@ -30,9 +30,9 @@ data _≡_ {A : Set} (x : A) : A → Set  where
 infix 4 _≡_
 \end{code}
 
-yields
+that yields the following statements:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 refl {ℕ} {0} : 0 ≡ 0
 refl {ℕ} {1} : 1 ≡ 1
 refl {ℕ} {2} : 2 ≡ 2
@@ -43,40 +43,40 @@ refl {Bool} {not b} : not b ≡ not b   -- if 'b : Bool' is a parameter
 ...
 ~~~~~~~~~~~~~~~~~
 
+`_≡_` as an equivalence and a congruence
+========================================
 
-`_≡_` is an equivalence and a congruence
-==============================
-
-`_≡_` is an equivalence-relation:
+Note that `_≡_` is an equivalence relation:
 
 \begin{code}
 refl'  : ∀ {A} (a : A) → a ≡ a
 refl' a = refl
 
 sym   : ∀ {A} {a b : A} → a ≡ b → b ≡ a
-sym refl = refl   -- after pattern matching on 'refl', 'a' and 'b' coincides
+sym refl = refl
 \end{code}
 
-*Exercise*
+In the definition of `sym`, we can prove the symmetry with pattern matching on
+`refl`, in which case `a` and `b` coincides.
 
+Exercises
+---------
+
+1. Prove that `≡` is a transitive relation:
+
+     `trans : ∀ {A} {a b c : A} → a ≡ b → b ≡ c → a ≡ c`
+
+1. Prove that every function is compatible with the equivalence relation,
+   which is called congruency:
+
+     `cong : ∀ {A B} {m n : A} → (f : A → B) → m ≡ n → f m ≡ f n`
+
+<!--
 \begin{code}
 trans : ∀ {A} {a b c : A} → a ≡ b → b ≡ c → a ≡ c
-\end{code}
-
-<!--
-\begin{code}
 trans refl refl = refl --
-\end{code}
--->
 
-Prove that every function is compatible with the equivalence relation (congruency):
-
-\begin{code}
 cong : ∀ {A B} {m n : A} → (f : A → B) → m ≡ n → f m ≡ f n
-\end{code}
-
-<!--
-\begin{code}
 cong f refl = refl --
 \end{code}
 -->
@@ -84,52 +84,47 @@ cong f refl = refl --
 Automatic reduction of types
 ============================
 
-Agda reduces types automatically during type checking.  
-This is safe because all functions terminate.
-
-Example:
+Agda reduces types automatically during type checking.  That is safe because
+all functions terminate (that is, they are all total functions).  For example:
 
 `1 + 1 ≡ 2`  ⇓  `2 ≡ 2`.
 
-Consequences:
+Note the consequences:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 refl : 1 + 1 ≡ 2
 ...
 refl : 0 + n ≡ n    -- if 'n : ℕ' is a parameter
 ...
 ~~~~~~~~~~~~~~~~~
 
-
 Definitional and propositional equality
-==============================
+=======================================
 
 `x` and `y` are definitionally equal iff `refl : x ≡ y`.
 
 "Definitional equality is trivial equality."
 
-*Example*
+As an example, consider the following:
 
 \begin{code}
 1+1≡2 : 1 + 1 ≡ 2
 1+1≡2 = refl
 \end{code}
 
-*Counterexample*
+While as a counterexample, consider this.  Suppose that `n : ℕ` is a
+parameter.
 
-Suppose that `n : ℕ` is a parameter.
-
-~~~~~~~~~~~~~~~~~ 
-refl : n + 0 ≡ 0 + n   -- type error!
+~~~~~~~~~~~~~~~~~
+refl : n + 0 ≡ 0 + n
 ~~~~~~~~~~~~~~~~~
 
-This doesn't typecheck because  
-`n + 0 ≡ 0 + n` ⇓ `n + 0 ≡ n`  
-and `n + 0` is not the same as `n`.
-
+Here, we will get a type error, that is it will not typecheck
+because `n + 0 ≡ 0 + n` ⇓ `n + 0 ≡ n`  and `n + 0` is not the
+same as `n`.
 
 Proof of `a + 0 ≡ a`
-=====================
+====================
 
 \begin{code}
 +-right-identity : ∀ n → n + 0 ≡ n
@@ -137,45 +132,33 @@ Proof of `a + 0 ≡ a`
 +-right-identity (suc n) = cong suc (+-right-identity n)
 \end{code}
 
-So `n + 0 ≡ n` is not trivial,  
-but for any `n` we can construct the proof of it.
+Thus `n + 0 ≡ n` is not trivial to prove, but for any `n`, we can construct the
+proof for it.  While that is a bit funny though:
 
-This is a bit funny though:
-
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 +-right-identity 0   ⇓  refl
 +-right-identity 1   ⇓  refl
 +-right-identity 2   ⇓  refl
 ...
 ~~~~~~~~~~~~~~~~~
 
-So the code of `+-right-identity` is kind of dead code
-(doesn't do anything meaningful at run time).  
-We'll discuss this later.
-
-
+That is, the code of `+-right-identity` is kind of dead code (which does not do
+anything meaningful at run time).  We will come back to this later.
 
 Exercises
-================================
+---------
 
 Finish the ingredients of the proof that (`ℕ`, `_+_`) is a commutative monoid!
 
 \begin{code}
 +-left-identity  : ∀ a → 0 + a ≡ a
-\end{code}
-
-<!--
-\begin{code}
-+-left-identity a = refl --
-\end{code}
--->
-
-\begin{code}
 +-assoc          : ∀ a b c → a + (b + c) ≡ (a + b) + c -- hint: use cong
 \end{code}
 
 <!--
 \begin{code}
++-left-identity a = refl --
+
 +-assoc zero    b c = refl --
 +-assoc (suc a) b c = cong suc (+-assoc a b c) --
 \end{code}
@@ -183,10 +166,11 @@ Finish the ingredients of the proof that (`ℕ`, `_+_`) is a commutative monoid!
 | +-identity a = +-left-identity a , +-right-identity a --
 -->
 
-For commutativity you need a helper function first:
+For proving the commutativity, you will need a helper function first:
 
 \begin{code}
 m+1+n≡1+m+n : ∀ m n → m + suc n ≡ suc (m + n)
++-comm      : ∀ a b → a + b ≡ b + a
 \end{code}
 
 <!--
@@ -194,7 +178,6 @@ m+1+n≡1+m+n : ∀ m n → m + suc n ≡ suc (m + n)
 m+1+n≡1+m+n zero n = refl  --
 m+1+n≡1+m+n (suc m) n = cong suc (m+1+n≡1+m+n m n) --
 
-+-comm : ∀ a b → a + b ≡ b + a
 +-comm zero b = sym (+-right-identity b)  --
 +-comm (suc n) b = trans  --
   (cong suc (+-comm n b)) --
@@ -202,63 +185,43 @@ m+1+n≡1+m+n (suc m) n = cong suc (m+1+n≡1+m+n m n) --
 \end{code}
 -->
 
-
 Exercise: `List ⊤` ~ `ℕ`
-======================
+------------------------
 
-Let
+Consider the following function definitions:
 
 \begin{code}
 fromList : List ⊤ → ℕ
-fromList [] = zero
+fromList []       = zero
 fromList (x ∷ xs) = suc (fromList xs)
 
 toList : ℕ → List ⊤
-toList zero = []
+toList zero    = []
 toList (suc n) = tt ∷ toList n
 \end{code}
 
-Let's prove that `fromList` and `toList` are inverses of each other and that they preserve the operations `_++_` and `_+_`!
+Let us prove that `fromList` and `toList` are inverses of each other and that
+they preserve the `_++_` and `_+_` operations.
 
 \begin{code}
 from-to : ∀ a → fromList (toList a) ≡ a
-\end{code}
-
-<!--
-\begin{code}
-from-to zero = refl  --
-from-to (suc a) = cong suc (from-to a)  --
-\end{code}
--->
-
-\begin{code}
 to-from : ∀ a → toList (fromList a) ≡ a
-\end{code}
 
-<!--
-\begin{code}
-to-from [] = refl  --
-to-from (x ∷ n) = cong (_∷_ tt) (to-from n)  --
-\end{code}
--->
-
-\begin{code}
 fromPreserves++ : ∀ (a b : List ⊤) → fromList (a ++ b) ≡ fromList a + fromList b
+toPreserves+    : ∀ (a b : ℕ) → toList (a + b) ≡ toList a ++ toList b
 \end{code}
 
 <!--
 \begin{code}
+from-to zero    = refl  --
+from-to (suc a) = cong suc (from-to a)  --
+
+to-from []      = refl  --
+to-from (x ∷ n) = cong (_∷_ tt) (to-from n)  --
+
 fromPreserves++ [] b = refl --
 fromPreserves++ (x ∷ xs) b = cong suc (fromPreserves++ xs b) --
-\end{code}
--->
 
-\begin{code}
-toPreserves+ : ∀ (a b : ℕ) → toList (a + b) ≡ toList a ++ toList b
-\end{code}
-
-<!--
-\begin{code}
 toPreserves+ zero    b = refl --
 toPreserves+ (suc n) b = cong (_∷_ tt) (toPreserves+ n b) --
 \end{code}
@@ -267,7 +230,7 @@ toPreserves+ (suc n) b = cong (_∷_ tt) (toPreserves+ n b) --
 Equational reasoning
 ====================
 
-Equational reasoning is *not* a new language construct!
+Equational reasoning is *not* a new language construct.
 
 \begin{code}
 _≡⟨_⟩_ : ∀ {A : Set} (x : A) {y z : A} → x ≡ y → y ≡ z → x ≡ z
@@ -281,7 +244,7 @@ x ∎ = refl
 infix  3 _∎
 \end{code}
 
-Usage example:
+This could be then used in the following way:
 
 \begin{code}
 +-comm' : (n m : ℕ) → n + m ≡ m + n
@@ -297,18 +260,15 @@ Usage example:
     ∎
 \end{code}
 
-
-
 Properties of `_*_`
-==============================
+===================
 
-We'd like to prove that (`ℕ`, `_*_`) is a commutative monoid.
-
-We will need distributivity:
+We would like to prove that (`ℕ`, `_*_`) is a commutative monoid.  In order
+to do so, first we will need distributivity:
 
 \begin{code}
 distribʳ-*-+ : ∀ a b c → (a + b) * c ≡ a * c + b * c
-distribʳ-*-+ zero b c = refl
+distribʳ-*-+ zero    b c = refl
 distribʳ-*-+ (suc a) b c =
     c + (a + b) * c
   ≡⟨ cong (λ x → c + x) (distribʳ-*-+ a b c) ⟩
@@ -318,16 +278,37 @@ distribʳ-*-+ (suc a) b c =
   ∎
 \end{code}
 
+We can also see that the proof involves using the so-called λ-functions.  Such
+functions are basically functions without names, and can be used at places
+where we would have defined a function for a single use only.
 
-Define the following functions:
+Their syntax is as follows:
+
+~~~~
+λ x → E(x)
+~~~~
+
+where `x` is a variable bound by `λ` as a quantifier, and `E(x)` is the scope
+of this variable.  It corresponds to such a function, with the name, `f`
+missing:
+
+~~~~
+f x = E(x)
+~~~~
+
+Define the following functions (or, rather, prove the following series of
+lemmata):
 
 \begin{code}
-*-assoc        : ∀ a b c → a * (b * c) ≡ (a * b) * c
+*-assoc          : ∀ a b c → a * (b * c) ≡ (a * b) * c
+*-left-identity  : ∀ a → 1 * a ≡ a
+*-right-identity : ∀ a → a * 1 ≡ a
+*-identity       : ∀ a → 1 * a ≡ a × a * 1 ≡ a
 \end{code}
 
 <!--
 \begin{code}
-*-assoc zero b c = refl --
+*-assoc zero    b c = refl --
 *-assoc (suc a) b c = --
     b * c + a * (b * c) --
   ≡⟨  cong (λ x → (b * c) + x) (*-assoc a b c) ⟩ --
@@ -335,52 +316,29 @@ Define the following functions:
   ≡⟨ sym (distribʳ-*-+ b (a * b) c) ⟩ --
     (b + a * b) * c --
   ∎ --
-\end{code}
--->
 
-\begin{code}
-*-left-identity  : ∀ a → 1 * a ≡ a
-\end{code}
-
-<!--
-\begin{code}
 *-left-identity a = +-right-identity a --
-\end{code}
--->
 
-\begin{code}
-*-right-identity : ∀ a → a * 1 ≡ a
-\end{code}
-
-<!--
-\begin{code}
 *-right-identity zero    = refl --
 *-right-identity (suc n) = cong suc (*-right-identity n) --
-*-identity       : ∀ a → 1 * a ≡ a × a * 1 ≡ a --
+
 *-identity a = *-left-identity a , *-right-identity a --
 \end{code}
 -->
 
-Commutativity:
+Proving commutativity:
 
 \begin{code}
--- helper functions:
-n*0≡0 : ∀ n → n * 0 ≡ 0
+n*0≡0  : ∀ n → n * 0 ≡ 0
+*-suc  : ∀ n m → n + n * m ≡ n * suc m
+*-comm : ∀ m n → m * n ≡ n * m
 \end{code}
 
 <!--
 \begin{code}
 n*0≡0 zero    = refl --
 n*0≡0 (suc n) = n*0≡0 n --
-\end{code}
--->
 
-\begin{code}
-*-suc : ∀ n m → n + n * m ≡ n * suc m
-\end{code}
-
-<!--
-\begin{code}
 *-suc zero m = refl --
 *-suc (suc n) m = cong suc $ --
     n + (m + n * m) --
@@ -394,15 +352,7 @@ n*0≡0 (suc n) = n*0≡0 n --
     m + n * suc m --
   ∎ --
   -- hint: you will need steps like this: cong (λ x → n + x) ...
-\end{code}
--->
 
-\begin{code}
-*-comm : ∀ m n → m * n ≡ n * m
-\end{code}
-
-<!--
-\begin{code}
 *-comm zero n = sym $ n*0≡0 n --
 *-comm (suc m) n =  --
     n + m * n --
@@ -412,14 +362,19 @@ n*0≡0 (suc n) = n*0≡0 n --
     n * suc m --
   ∎ --
 \end{code}
--->
-
-<!--
 | Browse and read the Agda standard libraries: [http://www.cse.chalmers.se/\~nad/listings/lib-0.5/](http://www.cse.chalmers.se/~nad/listings/lib-0.5/)
 -->
 
 Semiring solver
 ===============
+
+As another approach to proving certain properties about operations, one may
+consider using the `SemiringSolver` module.  This exports the `solve` function
+that could be fed with the abstract representation of the theorem to be
+proven, and then it tries to find (construct) a proof for that.
+
+Note that it has to be imported together with the `Data.Nat.Properties`
+module.
 
 \begin{code}
 module trySemiringSolver where
@@ -432,6 +387,3 @@ open import Relation.Binary.PropositionalEquality renaming (_≡_ to _≡-offici
 f : ∀ a b c → a + b * c + 1 ≡-official 1 + c * b + a
 f = solve 3 (λ a b c → a :+ b :* c :+ con 1 := con 1 :+ c :* b :+ a) refl
 \end{code}
-
-
-

--- a/tutorial/src/Functions/Functions_vs_Sets.lagda
+++ b/tutorial/src/Functions/Functions_vs_Sets.lagda
@@ -3,14 +3,17 @@
 \begin{code}
 module Functions.Functions_vs_Sets where
 
-open import Data.Bool using (Bool; true; false)
+open import Sets.Enumerated using (Bool; true; false)
 \end{code}
 
+Now, that we have seen sets and functions, it may make sense to compare them
+and discuss the observed differences.
 
 Negation as a relation
 ============================
 
-Representation of negation as a relation between `Bool` and `Bool`:
+Recall how the logical negation can be represented as a relation between
+values of the `Bool` and `Bool` sets:
 
 \begin{code}
 data Not : Bool → Bool → Set where
@@ -18,7 +21,7 @@ data Not : Bool → Bool → Set where
   n₂ : Not false true
 \end{code}
 
-This creates four new sets of which two are non-empty.
+Note that this will create four new sets of which two are non-empty.
 
 `Not a b` is non-empty iff `b` is the negated value of `a`.
 
@@ -26,7 +29,7 @@ This creates four new sets of which two are non-empty.
 Negation as a function
 ============================
 
-Recall the representation of negation as a function:
+Now consider the representation of the negation as a function:
 
 \begin{code}
 not : Bool → Bool
@@ -38,58 +41,57 @@ not false = true
 Relations vs. functions
 =====================
 
-Relation's advantages:
+Benefits of using relations:
 
--   Less restrictions
-    -   not all cases should be covered (partial specification)
+-   Less restrictions:
+
+    -   not all the cases should be covered (partial specification)
     -   redundancy is allowed
     -   general recursion is allowed
-    -   inconsistency is allowed (resulting in an empty relation)
--   Shorter definitions
-    (the difference increases with complexity)
+    -   inconsistency is allowed (that is, an empty relation)
 
-Function's advantages:
+-   Shorter definitions (the difference increases with complexity)
 
--   More guarantees
-    -   coverage check ensures that all cases are covered 
-    -   reachability check excludes multiple cases  
-    -   termination check ensures terminating recursion
-    -   inconsistency is excluded by construction
--   Functions have computational content
-    -   code generation possibility
+Benefits of using functions:
+
+-   More and better guarantees:
+
+    -   *coverage check* ensures that all cases are covered
+    -   *reachability check* excludes redundant cases
+    -   *termination check* ensures termination for recursion
+    -   inconsistency is excluded *by construction*
+
+-   Functions have computational content:
+
+    -   code generation is possible
     -   shorter proofs (see later)
--   Easier to use  
-    `not (not a)` instead of `Not a b ∧ Not b c`
+
+-   Ease of use, cf. `not (not a)` and `Not a b ∧ Not b c`
 
 
 Specification vs. implementation
 =====================
 
-Relations are good for describing the problem/question (**specification**).
+- Relations are useful for describing the problem/question (that is, a
+  *specification*).
 
-Functions are good for describing the solution/answer (**implementation**).
+- Functions are useful for describing the solution/answer (that is, an
+  *implementation*).
 
-*Notes*
+Remarks:
 
--   Implementations are connected to specifications by the type system (see later).  
--   Functions are used in specifications too because of the advantage
-    "easier to use" and they can represent negation and universal quantification.
-    -   like in mathematics where definitions
-        may need theorems in advance
+- Implementations are connected to specifications by the type system (see later).
 
+- Functions are also used in specifications due to their ease of use and because
+  they can conveniently represent negation and universal quantification.
 
-Functions with Boolean value
-============================
+    - Just like in mathematics where definitions may rely on previously known
+      theorems.
 
-*Remark*
+Functions with a Boolean value (predicates)
+===========================================
 
-An `A → B → C` function
-corresponds to specification
-`A → B → C → Set` according our previous remark.
-So `_≤?_ : ℕ → ℕ → Bool` would correspond to `ℕ → ℕ → Bool → Set`,
-but Boolean valued functions can be specified easier
-so we have `_≤_ : ℕ → ℕ → Set` as specification.
-
-
-
-
+An `A → B → C` function corresponds to the specification `A → B → C → Set`
+according the previous remarks.  That is, `_≤?_ : ℕ → ℕ → Bool` would
+correspond to `ℕ → ℕ → Bool → Set`, but actually it is easier to define
+Boolean-valued functions, so we have `_≤_ : ℕ → ℕ → Set` as specification.

--- a/tutorial/src/Functions/Large.lagda
+++ b/tutorial/src/Functions/Large.lagda
@@ -1,8 +1,8 @@
-% Functions with Sets Result
+% Functions with Set Results
 
 
-Imports
-========
+Import list
+===========
 
 \begin{code}
 module Functions.Large where
@@ -16,24 +16,24 @@ open import Data.Sum using (_⊎_; inj₁; inj₂)
 Introduction
 ============
 
-Function definitions give another possibility to define sets.  
-We give general design rules on which language construct to use.
+Function definitions give another possibility to define sets.  Here we will
+give general design guidelines on which language construct to use in certain
+situations.
 
-
-Inductive `_≤_` definition
+Inductive definition of `_≤_`
 ==========
 
-The *inductive* definition of `_≤_`:
+Consider the *inductive* definition of `_≤_` as follows:
 
 \begin{code}
 data  _≤_ : ℕ → ℕ → Set where
-  z≤n : {n : ℕ} →               zero  ≤ n
-  s≤s : {m n : ℕ} →   m ≤ n  →  suc m ≤ suc n
+  z≤n : {n : ℕ}   →         zero  ≤ n
+  s≤s : {m n : ℕ} → m ≤ n → suc m ≤ suc n
 \end{code}
 
-which yields the statements
+that will yield the following statements:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 z≤n : 0 ≤ 0
 z≤n : 0 ≤ 1
 z≤n : 0 ≤ 2
@@ -46,14 +46,13 @@ s≤s (s≤s z≤n) : 2 ≤ 2
 s≤s (s≤s z≤n) : 2 ≤ 3
 s≤s (s≤s z≤n) : 2 ≤ 4
 ...
-...
 ~~~~~~~~~~~~~~~~~
 
-
-Recursive `_≤_` definition
+Recursive definition of `_≤_`
 ==========
 
-The *recursive* definition of less-than-or-equal:
+In comparison, now consider the *recursive* definition of `_≤_` as follows
+(written as `_≤′_`):
 
 \begin{code}
 _≤′_ : ℕ → ℕ → Set
@@ -62,9 +61,9 @@ suc m ≤′ zero  = ⊥
 suc m ≤′ suc n = m ≤′ n
 \end{code}
 
-which yields the statements
+that will yield the following statements:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 tt : 0 ≤′ 0
 tt : 0 ≤′ 1
 tt : 0 ≤′ 2
@@ -77,54 +76,56 @@ tt : 2 ≤′ 2
 tt : 2 ≤′ 3
 tt : 2 ≤′ 4
 ...
-...
 ~~~~~~~~~~~~~~~~~
 
 
 Inductive vs. recursive definitions
 ===============
 
-`_≤_` and `_≤′_` have the same type and define exactly the same relations. But:
+`_≤_` and `_≤′_` have the same type and define exactly the same relations.  But
+note that:
 
-**Inductive definitions are better than
-recursive definitions with pattern matching.**
+**Inductive definitions are better than recursive definitions with pattern
+matching.**
 
-*Explanation*
+Suppose that we have `n : ℕ`, `m : ℕ` in a function definition.
 
-Suppose in a function definition we have `n : ℕ`, `m : ℕ`.
+ - In case of `e : n ≤ m`, we *can* pattern match on `e` -- the possible cases
+   are `z≤n` and `s≤s x`.
 
--   In case of `e : n ≤ m` we *can* pattern match on `e`; the possible cases are `z≤n` and `s≤s x`.
--   In case of `e : n ≤′ m` we *cannot* pattern match on `e`, because the type of `e` is not yet known
-    to be `⊥` or `⊤`. We should pattern match on `n` and `m` before to learn more about `n ≤′ m`.
+ - In case of `e : n ≤′ m`, we *cannot* pattern match on `e`, because the type
+   of `e` is not yet known to be either `⊥` or `⊤`. We should pattern match on
+   `n` and `m` before to we could learn more about `n ≤′ m`.
 
-Example (we discuss *dependent functions* like this later):
+For example (we are going to discuss *dependent functions* like this one
+later):
 
 \begin{code}
 f : {n m : ℕ} → n ≤ m → n ≤ suc m
-f z≤n = z≤n
+f z≤n     = z≤n
 f (s≤s x) = s≤s (f x)
 
 f′ : {n m : ℕ} → n ≤′ m → n ≤′ suc m
-f′ {zero} {m} tt = tt
-f′ {suc n} {zero} ()
-f′ {suc n} {suc m} x = f′ {n} {m} x
+f′ {zero}  {m}     tt = tt
+f′ {suc n} {zero}  ()
+f′ {suc n} {suc m} x  = f′ {n} {m} x
 \end{code}
 
 <!--
 \begin{code}
 conv : {n m : ℕ} → n ≤′ m → n ≤ m  --
-conv {zero} tt = z≤n  --
+conv {zero}         tt = z≤n  --
 conv {suc n} {zero} ()  --
 conv {suc n} {suc m} e = s≤s (conv e) --
 \end{code}
 -->
 
 Exercises
-========
+---------
 
-Give recursive definitions for `_≡_` and `_≢_` on natural numbers!
+ #. Give recursive definitions for `_≡_` and `_≢_` on natural numbers.
 
-Give mutual recursive definitions for `Even` and `Odd`!
+ #. Give mutual recursive definitions for the `Even` and `Odd` sets.
 
 <!--
 \begin{code}
@@ -143,50 +144,63 @@ Odd (suc n) = Even n --
 Macro-like `Set` definitions
 =================
 
-Macro-like functions don't pattern match on their argument:
+We can create macro-like function definitions that do not pattern match on
+their argument:
 
 \begin{code}
 _<_ : ℕ → ℕ → Set
 n < m = suc n ≤ m
 \end{code}
 
-Although we could have an inductive definition of `_<_`,
-this definition is better because
-no conversion functions are needed between `_≤_` and `_<_`.
+Although we could have an inductive definition of `_<_`, this definition is
+better because no conversion functions are needed between `_≤_` and `_<_`.
 
-On the other hand,
+On the other hand, while the following would be also possible:
 
 \begin{code}
 Maybe : Set → Set
 Maybe A = ⊤ ⊎ A
 \end{code}
 
-is possible, but not advised because then we can't
-distinguish `Maybe ⊤` from `⊤ ⊎ ⊤`, for example.
+in general, this is not advised because then we cannot distinguish
+`Maybe ⊤` from `⊤ ⊎ ⊤`, for example.
 
-*General rule:*  
+We can summarize the general rule as follows:
+
 **Macro-like `Set` definitions are better than inductive definitions if
-we don't want to distinguish the new type from the base type.**
+we do not want to distinguish the new (derived) type from the base
+type.**
 
-Exercises
-========
+Exercise
+--------
 
-Define `_>_` and `_≥_` on top of `_≤_`!
-
+Define `_>_` and `_≥_` on top of `_≤_`.
 
 Another example
 ===============
+
+A good example of the macro-like behavior is the definition of the `¬`
+function.  This is used to create a shorthand for writing negated statements
+(which we are also going to use later).
 
 \begin{code}
 ¬ : Set → Set
 ¬ A = A → ⊥
 \end{code}
 
-
 Another example: recursive `Fin`
 ================================
 
-`Fin₀ n` is isomorphic to `Fin n` for all `n`:
+Recall the definition of the `Fin` indexed type from earlier:
+
+\begin{code}
+data Fin : ℕ → Set where
+  zero : (n : ℕ) → Fin (suc n)
+  suc  : (n : ℕ) → Fin n → Fin (suc n)
+\end{code}
+
+With this in mind, consider the `Fin₀` function, where `Fin₀ n` is isomorphic
+to `Fin n` for all `n`:
 
 \begin{code}
 Fin₀ : ℕ → Set
@@ -194,8 +208,7 @@ Fin₀ zero    = ⊥
 Fin₀ (suc n) = ⊤ ⊎ Fin₀ n
 \end{code}
 
-
-Elements:
+Compare the produced elements:
 
     n    Fin₀ n                             Fin n
     ------------------------------------------------------------------
@@ -212,7 +225,7 @@ Elements:
          , inj₂ (inj₂ (inj₂ (inj₁ tt))) }   , suc (suc (suc zero)) }
     ...
 
-Pattern:
+Based on the table above, we can observe the following pattern:
 
  * `zero` ~ `inj₁ tt`
  * `suc` ~ `inj₂`

--- a/tutorial/src/Functions/Polymorphic.lagda
+++ b/tutorial/src/Functions/Polymorphic.lagda
@@ -26,11 +26,14 @@ data List (A : Set) : Set where
 infixr 5 _∷_
 \end{code}
 
+Remember this is a polymorphic definition.
 
-`_++_` : Concatenation on Lists
-===========================
 
-Definition of concatenation:
+`_++_` : Concatenation on lists
+===============================
+
+Using the definition of the `List` set above, the definition of list
+concatenation can be given as follows:
 
 \begin{code}
 _++_ : {A : Set} → List A → List A → List A
@@ -40,9 +43,10 @@ _++_ : {A : Set} → List A → List A → List A
 infixr 5 _++_
 \end{code}
 
-`_++_` works with `List`s parametrised by arbitrary `Set`s. 
-We call this parameter a polymorphic parameter and `_++_` a polymorphic function.
-Polymorphic parameters have to be named explicitly in beginning of the declaration of the function by putting them into curly braces:
+The `_++_` operator works with `List`s parametrised by arbitrary `Set`s.
+We call its parameters polymorphic, and thus `_++_` a polymorphic function.
+Polymorphic parameters have to be named explicitly in beginning of the
+declaration of the function by putting them into curly braces:
 
     f : {A B C : Set} → ...
 
@@ -51,9 +55,8 @@ Polymorphic parameters have to be named explicitly in beginning of the declarati
 In Agda, polymorphic parameters are explicit, in Haskell they are implicit.
 
 Instead of curly braces we can use also round braces but then
-we have to give the set as a parameter at every function call.
-
-
+we have to give the set as a parameter at every function call, which
+may make it clearer but also more inconvenient to use.
 
 <!--
 | Exercises: `head` and `tail` on Lists
@@ -103,75 +106,51 @@ we have to give the set as a parameter at every function call.
 -->
 
 Exercises
-=========
+---------
 
-*   Define two functions which define the isomorphism between `List ⊤` and `ℕ`!
+1. Define two functions that define an isomorphism between `List ⊤` and `ℕ`.
+   That is, the following functions should be implemented:
 
+     `fromList : List ⊤ → ℕ`  
+     `toList   : ℕ → List ⊤`
+
+1. Show on a sheet of paper with equational reasoning that the `fromList`
+   function is a bijection and it preserves the `_+_` and `_++_`
+   operations (that is, `∀ a, b ∈ List ⊤ . fromList (a ++ b) = fromList a + fromList b` always holds).
+
+1. Define a `Maybe` set (a list with 0 or 1 elements) together with the
+   `head` and `tail` functions for the polymorphic `List` type, with the
+   help of `Maybe`.
+
+1. Define the following functions on lists:
+
+     `map  : {A B : Set} → (A → B)      → List A → List B -- regular map`  
+     `maps : {A B : Set} → List (A → B) → List A → List B -- pairwise map`
+
+1. Define the singleton list function:
+
+     `[_] : {A : Set} → A → List A`
+
+<!--
 \begin{code}
 fromList : List ⊤ → ℕ
-\end{code}
-
-<!--
-\begin{code}
 fromList []        = zero --
 fromList (tt ∷ xs) = suc (fromList xs) --
-\end{code}
--->
 
-\begin{code}
 toList   : ℕ → List ⊤
-\end{code}
-
-<!--
-\begin{code}
 toList zero    = [] --
 toList (suc n) = tt ∷ toList n --
-\end{code}
--->
 
-*   Show on a sheet of paper with equational reasoning that the `fromList` function is a bijection and it preserves the `_+_` and `_++_` operations (that is, `∀ a, b ∈ List ⊤ . fromList (a ++ b) = fromList a + fromList b`).
-
-*   Define a `Maybe` set (lists with 0 or 1 elements)
-    and `head` and `tail` functions for the polymorphic `List` type with the help of `Maybe`.
-
-
-
-Exercises
-=========
-
-Define the following functions on lists:
-
-\begin{code}
 map  : {A B : Set} → (A → B)      → List A → List B -- regular map
-\end{code}
-
-<!--
-\begin{code}
 map f []       = [] --
 map f (x ∷ xs) = f x ∷ map f xs --
-\end{code}
--->
 
-\begin{code}
 maps : {A B : Set} → List (A → B) → List A → List B -- pairwise map
-\end{code}
-
-<!--
-\begin{code}
 maps []       _        = [] --
 maps _        []       = [] --
 maps (f ∷ fs) (x ∷ xs) = f x ∷ (maps fs xs) --
-\end{code}
--->
 
-Define the singleton list function:
-
-\begin{code}
 [_] : {A : Set} → A → List A
-\end{code}
-
-<!--
-\begin{code}
 [ a ] = a ∷ [] --
 \end{code}
 -->
@@ -206,37 +185,41 @@ Define the singleton list function:
 | In the second case we let Agda guess the value of the first parameter.
 -->
 
-Polymorphic `id` function
-=========================
+Polymorphic identity function: `id`
+===================================
 
 <!--
 | If we tend to put an `_` in place of a parameter it probably means that it can be made implicit, that is, we could rely on Agda to guess the value. We can do this putting the parameter in curly braces:
 -->
+
+Similarly to the concatenation function above, a polymorphic identity
+function can be also given with the same notation, which is an example
+of generic polymorphic functions.
 
 \begin{code}
 id : {A : Set} → A → A
 id a = a
 \end{code}
 
-If we want, can specify the implicit parameter manually in curly braces:
+If we want we can specify the implicit (hidden) parameter manually in
+curly braces:
 
 \begin{code}
 aNumber = id {ℕ} (suc zero)
 \end{code}
 
-Exercise
-========
+Exercises
+---------
 
-Define `const : {A B : Set} → A → B → A`!
+1. Define the `const : {A B : Set} → A → B → A` function.
 
-Define `flip : {A B C : Set} → (A → B → C) → B → A → C`!
+1. Define the `flip : {A B C : Set} → (A → B → C) → B → A → C` function.
 
 
-
-`_×_`: Cartesian Product
+`_×_`: Cartesian product
 ========================
 
-Recall the definition of Cartesian product:
+Recall the definition of the product set:
 
 \begin{code}
 data _×_ (A B : Set) : Set where
@@ -247,28 +230,29 @@ infixr 2 _×_
 \end{code}
 
 Exercises
-=========
+---------
 
-Define a function which swaps the two elements!
+1. Define a function that swaps the two elements.
 
-Define the following functions:
+1. Define the following functions:
 
-\begin{code}
-proj₁ : {A B : Set} → A × B → A
-\end{code}
+     `proj₁ : {A B : Set} → A × B → A`  
+     `proj₂ : {A B : Set} → A × B → B`
 
 <!--
 \begin{code}
+proj₁ : {A B : Set} → A × B → A
 proj₁ (a , _) = a --
+
 proj₂ : {A B : Set} → A × B → B
 proj₂ (_ , b) = b --
 \end{code}
 -->
 
-`_⊎_`: Disjoint Union (Sum)
-===================================
+`_⊎_`: Disjoint union (sum)
+===========================
 
-Recall the definition
+Recall the definition of the sum set:
 
 \begin{code}
 data _⊎_ (A B : Set) : Set where
@@ -278,22 +262,19 @@ data _⊎_ (A B : Set) : Set where
 infixr 1 _⊎_
 \end{code}
 
-
 Exercises
-=========
+---------
 
-Define a function which swaps the two elements!
+1. Define a function that swaps the two elements.
 
-Define the eliminator function for disjoint union:
+1. Define the eliminator function for disjoint union:
 
-\begin{code}
-[_,_] : {A B C : Set} → (A → C) → (B → C) → (A ⊎ B → C)
-\end{code}
+     `[_,_] : {A B C : Set} → (A → C) → (B → C) → (A ⊎ B → C)`
 
 <!--
 \begin{code}
+[_,_] : {A B C : Set} → (A → C) → (B → C) → (A ⊎ B → C)
 [_,_] f g (inj₁ a) = f a --
 [_,_] f g (inj₂ b) = g b --
 \end{code}
 -->
-

--- a/tutorial/src/Functions/Recursive.lagda
+++ b/tutorial/src/Functions/Recursive.lagda
@@ -4,7 +4,7 @@
 module Functions.Recursive where
 \end{code}
 
-Import List
+Import list
 ===========
 
 \begin{code}
@@ -12,11 +12,27 @@ open import Data.Bool using (Bool; true; false)
 open import Data.Nat using (ℕ; suc; zero)
 \end{code}
 
+Functions can be recursive as well, which is essential for working on sets that
+were defined recursively.  In this case, a common approach is to define an
+alternative for each of the constructors and when the constructor is recursive
+then the function itself shall also be probably recursive.
 
 `_+_`: Addition
-==================
+===============
 
-Definition of addition:
+Consider the previous definition of the `ℕ` type, where we had the following
+constructors with the following types:
+
+`zero : ℕ`  
+`suc  : ℕ → ℕ`
+
+Note that this was done along the lines of the mathematical definition of the
+Peano arithmetic.  Consider also the definion of how to calculate the sum of
+two natural numbers with this representation:
+
+$\begin{array}{rcl}0 + n & = & n \\ (1 + m) + n & = & 1 + (m + n) \end{array}$
+
+Now consider the same definition in Agda:
 
 \begin{code}
 _+_ : ℕ → ℕ → ℕ
@@ -26,125 +42,130 @@ suc m + n = suc (m + n)
 infixl 6 _+_
 \end{code}
 
-
-Exercises: `pred`, `_*_`, `_⊔_`, `_⊓_` and `⌊_/2⌋`
-=========
+Exercises
+---------
 
 Define the following functions:
 
-\begin{code}
+~~~~{.agda}
 pred  : ℕ → ℕ      -- predecessor (pred 0 = 0)
-\end{code}
+
+infixl 6 _∸_
+_∸_   : ℕ → ℕ → ℕ  -- subtraction (0 ∸ n = n)
+
+infixl 7 _*_
+_*_   : ℕ → ℕ → ℕ  -- multiplication
+
+infixl 6 _⊔_
+_⊔_   : ℕ → ℕ → ℕ  -- maximum
+
+infixl 7 _⊓_
+_⊓_   : ℕ → ℕ → ℕ  -- minimum
+
+⌊_/2⌋ : ℕ → ℕ      -- half (⌊ 1 /2⌋ = 0)
+
+odd   : ℕ → Bool   -- is odd
+
+even  : ℕ → Bool   -- is even
+~~~~
 
 <!--
 \begin{code}
+pred  : ℕ → ℕ      -- predecessor (pred 0 = 0)
 pred zero    = zero --
 pred (suc n) = n --
 \end{code}
 -->
 
+<!--
 \begin{code}
 infixl 6 _∸_
 _∸_   : ℕ → ℕ → ℕ  -- subtraction (0 ∸ n = n)
-\end{code}
-
-<!--
-\begin{code}
 zero  ∸ _     = zero --
 suc n ∸ zero  = suc n --
 suc n ∸ suc m = n ∸ m --
 \end{code}
 -->
 
+<!--
 \begin{code}
 infixl 7 _*_
 _*_   : ℕ → ℕ → ℕ  -- multiplication
-\end{code}
-
-<!--
-\begin{code}
 zero  * _ = zero --
 suc n * b = b + n * b --
 \end{code}
 -->
 
+<!--
 \begin{code}
 infixl 6 _⊔_
 _⊔_   : ℕ → ℕ → ℕ  -- maximum
-\end{code}
-
-<!--
-\begin{code}
 zero  ⊔ b     = b --
 a     ⊔ zero  = a --
 suc a ⊔ suc b = suc (a ⊔ b) --
 \end{code}
 -->
 
+<!--
 \begin{code}
 infixl 7 _⊓_
 _⊓_   : ℕ → ℕ → ℕ  -- minimum
-\end{code}
-
-<!--
-\begin{code}
 zero  ⊓ _     = zero --
 _     ⊓ zero  = zero --
 suc a ⊓ suc b = suc (a ⊓ b) --
 \end{code}
 -->
 
-\begin{code}
-⌊_/2⌋ : ℕ → ℕ      -- half (⌊ 1 /2⌋ = 0)
-\end{code}
-
 <!--
 \begin{code}
+⌊_/2⌋ : ℕ → ℕ      -- half (⌊ 1 /2⌋ = 0)
 ⌊ zero /2⌋        = zero --
 ⌊ suc zero /2⌋    = zero --
 ⌊ suc (suc n) /2⌋ = suc ⌊ n /2⌋ --
 \end{code}
 -->
 
-Exercises: `even`, `odd`
-=========
-
-\begin{code}
-odd   : ℕ → Bool   -- is odd
-\end{code}
-
 <!--
 \begin{code}
-odd zero          = false --
-odd (suc zero)    = true --
-odd (suc (suc n)) = odd n --
+-- odd zero          = false --
+-- odd (suc zero)    = true --
+-- odd (suc (suc n)) = odd n --
 \end{code}
 -->
 
-\begin{code}
-even  : ℕ → Bool   -- is even
-\end{code}
-
 <!--
 \begin{code}
-even zero          = true --
-even (suc zero)    = false --
-even (suc (suc n)) = even n --
+-- even zero          = true --
+-- even (suc zero)    = false --
+-- even (suc (suc n)) = even n --
 \end{code}
 -->
 
 Mutual definitions
-=========
+==================
 
-Define `even` and `odd` mutually with the `mutual` keyword!
+It is possible to define functions mutually, like we did for sets.  As an
+example, consider the mutual definition of the `even` and `odd` functions:
 
+~~~~{.agda}
+odd : ℕ → Bool
 
-Exercises: `_≡?_`, `_≤?_`
-=========
+even : ℕ → Bool
+even zero    = true
+even (suc n) = odd n
 
+odd zero    = false
+odd (suc n) = even n
+~~~~
+
+Exercises
+---------
+
+Define the following functions mutually:
 
 \begin{code}
 _≡?_  : ℕ → ℕ → Bool  -- is equal
+_≤?_  : ℕ → ℕ → Bool  -- is less than or equal
 \end{code}
 
 <!--
@@ -155,11 +176,6 @@ suc _ ≡? zero  = false --
 suc n ≡? suc m = n ≡? m --
 \end{code}
 -->
-
-\begin{code}
-_≤?_  : ℕ → ℕ → Bool  -- is less than or equal
-\end{code}
-
 <!--
 \begin{code}
 zero  ≤? _     = true --
@@ -168,9 +184,8 @@ suc n ≤? suc m = n ≤? m --
 \end{code}
 -->
 
-
 Binary representation of `ℕ`
-==============
+============================
 
 Import the binary representation of natural numbers:
 
@@ -178,7 +193,10 @@ Import the binary representation of natural numbers:
 open import Sets.Recursive using (ℕ⁺; one; double; double+1; ℕ₂; zero; id)
 \end{code}
 
-*Exercise:* define the conversion function:
+Exercise
+--------
+
+Define a conversion function of the following type:
 
 \begin{code}
 from : ℕ₂ → ℕ  -- hint: use _*_
@@ -193,8 +211,9 @@ from (id (double+1 n)) = suc (suc (suc zero) * from (id n)) --
 \end{code}
 -->
 
-`from` should define the backward function of the following isomorphism between `ℕ` and `ℕ₂`
-(we prove that `from` is an isomorphism later):
+Note that the `from` function shall define a reverse function of the following
+isomorphism between `ℕ` and `ℕ₂` (later we will prove that `from` is an
+isomorphism):
 
 **ℕ**                   **ℕ₂**
 ----------------------- --------------------------
@@ -204,16 +223,12 @@ from (id (double+1 n)) = suc (suc (suc zero) * from (id n)) --
 `suc (suc (suc zero))`  `id (double+1 one)`
 ...                     ...
 
-
-We will see how to define the conversion to the other direction later.
-
-
+Later we will see how to define the same conversion in the other direction.
 
 Exercises
-=========
+---------
 
-Define `ℤ` and some operations on it (`_+_`, `_-_`, `_*_`)!
-
+Define `ℤ` and some operations on it (such as `_+_`, `_-_`, `_*_`).
 
 Binary trees
 =========
@@ -224,9 +239,10 @@ data BinTree : Set where
   node : BinTree → BinTree → BinTree
 \end{code}
 
-*Exercise:* define (recursive) mirroring of binary trees!
+Exercise
+--------
 
+Define (recursive) mirroring of binary trees, that is a function with the
+following type:
 
-
-
-
+`mirror : BinTree → BinTree`

--- a/tutorial/src/Functions/Universal_Quantification.lagda
+++ b/tutorial/src/Functions/Universal_Quantification.lagda
@@ -1,6 +1,5 @@
 % Universal Quantification
 
-
 Imports
 ========
 
@@ -15,14 +14,11 @@ open import Function using (flip; _$_; _∘_)
 \end{code}
 
 
-
 Universal quantification
-======
+========================
 
 We can represent a proof for universal quantification on a set by
-a dependent function on that set.
-
-Example:
+a dependent function on that set.  For example:
 
 \begin{code}
 ≤-refl : (n : ℕ) → n ≤ n
@@ -31,13 +27,18 @@ Example:
 \end{code}
 
 Exercises
-=========
+---------
 
-Define the following functions (prove these properties):
+Define the following functions (that is, prove those properties):
 
 \begin{code}
-≤-trans      : ∀ {m n o} → m ≤ n → n ≤ o → m ≤ o
+≤-trans : ∀ {m n o} → m ≤ n → n ≤ o → m ≤ o
+total   : ∀ m n → m ≤ n ⊎ n ≤ m
+≤-pred  : ∀ {m n} → suc m ≤ suc n → m ≤ n
+≤-mono  : ∀ {m n k} → n ≤ m → k + n ≤ k + m
 \end{code}
+
+*Hint:*  For `total`, use the previously defined `[_,_]` function.
 
 <!--
 \begin{code}
@@ -45,15 +46,7 @@ Define the following functions (prove these properties):
 ≤-trans (s≤s m≤n) (s≤s n≤o) = s≤s (≤-trans m≤n n≤o) --
 -- antisym   : ∀ {m n} → m ≤ n → n ≤ m → m ≡ n  --
 --   (we will only define this after we have defined equality)  --
-\end{code}
--->
 
-\begin{code}
-total        : ∀ m n → m ≤ n ⊎ n ≤ m -- hint: use [_,_]′
-\end{code}
-
-<!--
-\begin{code}
 total zero    _       = inj₁ z≤n --
 total _       zero    = inj₂ z≤n --
 total (suc m) (suc n)  --
@@ -61,106 +54,49 @@ total (suc m) (suc n)  --
        (λ m≤n → inj₁ (s≤s m≤n)) --
        (λ n≤m → inj₂ (s≤s n≤m)) --
        (total m n) --
-\end{code}
--->
 
-From the 4 above properties follows that `_≤_` is a total order on `ℕ`. (We can look at `_≤_` as a relation over `ℕ`.)
-
-\begin{code}
-≤-pred  : ∀ {m n} → suc m ≤ suc n → m ≤ n
-\end{code}
-
-<!--
-\begin{code}
 ≤-pred (s≤s m≤n) = m≤n --
-\end{code}
--->
 
-\begin{code}
-≤-mono  : ∀ {m n k} → n ≤ m → k + n ≤ k + m
-\end{code}
-
-<!--
-\begin{code}
 ≤-mono {k = zero}  n≤m = n≤m --
 ≤-mono {k = suc k} n≤m = s≤s $ ≤-mono {k = k} n≤m --
 \end{code}
 -->
 
+Note that, from the properties above, it follows that `_≤_` is a total order
+on `ℕ`.  (We can take `_≤_` as a relation over `ℕ`.)
+
 Exercises
-=============
+---------
 
 Define the following functions:
 
 \begin{code}
 ≤-step : ∀ {m n} → m ≤ n → m ≤ 1 + n
+≤′⇒≤   : ∀ {a b} → a ≤′ b → a ≤ b
+z≤′n   : ∀ n → zero ≤′ n
+s≤′s   : ∀ {m n} → m ≤′ n → suc m ≤′ suc n
+≤⇒≤′   : ∀ {a b} → a ≤ b → a ≤′ b
+fin≤   : ∀ {n}(m : Fin n) → toℕ m < n
 \end{code}
 
 <!--
 \begin{code}
 ≤-step z≤n   = z≤n --
 ≤-step (s≤s m≤n) = s≤s (≤-step m≤n) --
-\end{code}
--->
 
-\begin{code}
-≤′⇒≤ : ∀ {a b} → a ≤′ b → a ≤ b
-\end{code}
-
-<!--
-\begin{code}
 ≤′⇒≤ ≤′-refl        = ≤-refl _ --
 ≤′⇒≤ (≤′-step m≤′n) = ≤-step $ ≤′⇒≤ m≤′n --
-\end{code}
--->
 
-\begin{code}
-z≤′n : ∀ n → zero ≤′ n
-\end{code}
-
-<!--
-\begin{code}
 z≤′n zero  = ≤′-refl --
 z≤′n (suc n) = ≤′-step (z≤′n _) --
-\end{code}
--->
 
-\begin{code}
-s≤′s : ∀ {m n} → m ≤′ n → suc m ≤′ suc n
-\end{code}
-
-<!--
-\begin{code}
 s≤′s ≤′-refl        = ≤′-refl --
 s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n) --
-\end{code}
--->
 
-\begin{code}
-≤⇒≤′ : ∀ {a b} → a ≤ b → a ≤′ b
-\end{code}
-
-<!--
-\begin{code}
 ≤⇒≤′ z≤n   = z≤′n _ --
 ≤⇒≤′ (s≤s a≤b) = s≤′s $ ≤⇒≤′ a≤b --
-\end{code}
--->
 
-
-Exercises with `Fin`
-====================
-
-Define `fin≤`:
-
-\begin{code}
-fin≤ : ∀ {n}(m : Fin n) → toℕ m < n
-\end{code}
-
-<!--
-\begin{code}
 fin≤ zero    = s≤s z≤n
 fin≤ (suc m) = s≤s (fin≤ m)
 \end{code}
 -->
-

--- a/tutorial/src/Installation.lagda
+++ b/tutorial/src/Installation.lagda
@@ -11,15 +11,19 @@ module Installation where
 Agda compiler
 ============
 
-General installation instruction can be found at the [Download](http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Main.Download) section of the Agda website.
+General installation instructions of the Agda compiler can be found at the
+[Download](http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Main.Download)
+section of the Agda website.
 
-The following instructions may be out of date.
+*Please note that the following instructions may be out of date.*
 
 
 Linux or FreeBSD
 ---------
 
-If you have Ubuntu / Debian / NixOS / some other decent Linux distro or FreeBSD, you can safely install Agda from your package manager. Or you can use cabal-install as described below for the Windows version.
+If you have Ubuntu / Debian / NixOS / some other decent Linux distro or
+even FreeBSD, you can safely install Agda from your package manager. Or
+you can use `cabal-install` as described below for the Windows version.
 
 After installation show Emacs where to find agda-mode by the following command:
 
@@ -28,18 +32,22 @@ After installation show Emacs where to find agda-mode by the following command:
 Windows
 -----------
 
-1. If you don't have Haskell platform and you have administrator access to the computer, try the [all-in-one Windows installer](http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Main.Windows).
-1. If you already have Haskell platform installed (and maybe don't have administrator access), you need to go through the following steps:
+1. If you do not have Haskell Platform installed but you have administrator
+   access to the computer, try the
+   [all-in-one Windows installer](http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Main.Windows).
 
-    1. Put GHC into `%PATH%` (cmd: `set PATH=%PATH%;"C:\Program Files\Haskell Platform\2011.2.0.1\bin";`)
-    1. install [Emacs](http://www.gnu.org/software/emacs/)
-    1. put Emacs into `%PATH%` (cmd: `set PATH=%PATH%;"c:\program files (x86)\emacs-23.3\bin";`)
-    1. put the cabal/bin folder into `%PATH%` (cmd: `set PATH=%PATH%;%APPDATA%\cabal\bin;`)
-    1. cmd: `cabal update`
-    1. cmd: `cabal install agda`
+1. If you already have Haskell Platform installed (but you may not necessarily
+   have administrator access), you will need to go through the following steps:
+
+    1. Put GHC into `%PATH%` (`set PATH=%PATH%;"C:\Program Files\Haskell Platform\2014.2.0.0\bin";`)
+    1. Install [Emacs](http://www.gnu.org/software/emacs/)
+    1. Put Emacs into `%PATH%` (`set PATH=%PATH%;"c:\program files (x86)\emacs-23.3\bin";`)
+    1. Put the cabal/bin folder into `%PATH%` (`set PATH=%PATH%;%APPDATA%\cabal\bin;`)
+    1. `cabal update`
+    1. `cabal install Agda`
     1. `agda-mode setup`  
        If that fails, you have two opportunities:
-        1. put `(load-file (let ((coding-system-for-read ‘utf-8)) (shell-command-to-string “agda-mode locate”)))` into your `.emacs` file (path is usually `Users/username/AppData/Roaming/.emacs`)
+        1. put `(load-file (let ((coding-system-for-read ‘utf-8)) (shell-command-to-string “agda-mode locate”)))` into your `.emacs` file (path is usually `Users\%USERNAME%\AppData\Roaming\.emacs`)
         1. after starting emacs, type `(load-file (let ((coding-system-for-read ‘utf-8)) (shell-command-to-string “agda-mode locate”)))` into the *scratch* buffer, select it with the mouse and type `M-x eval-region`
 
 1. If you neither have administrator access nor Haskell Platform installed: get administrator access!

--- a/tutorial/src/Modules/Basic.lagda
+++ b/tutorial/src/Modules/Basic.lagda
@@ -6,28 +6,29 @@
 Module headers
 ==============
 
-Every Agda module should have a *module header* like
+Every Agda module should have a *module header* like as follows:
 
 \begin{code}
 module Modules.Basic where
 \end{code}
 
- * `module` and `where` are keywords
- * The module name after `module` should correspond to the file name in the file system.  
-   In this case the file name is `Modules/Basic.agda` (or `Modules/Basic.lagda`).
- * Syntax highlighting is added by loading the module in Emacs with C-`c` C-`l`.
+Note that:
+
+ * The `module` and the `where` are keywords.
+ * The module name after `module` should correspond to the file name in the
+   file system.  In this case the file name is `Modules/Basic.agda` (or
+   `Modules/Basic.lagda`).
+ * Syntax highlighting is added by successfully loading the module in Emacs with
+   C-`c` C-`l`.
 
 
 Exercise
-==============
+--------
 
-1.  Install the Agda compiler
-1.  Open a file called "First.agda" (or similar) in Emacs
-1.  Fill in the module header
-1.  Load the module to get syntax highlighting
-
-
-
+1.  Install the Agda compiler.
+1.  Open a file called `First.agda` (or something similar) in Emacs.
+1.  Fill in the module header.
+1.  Load the module to get syntax highlighting.
 
 
 Declarations
@@ -41,8 +42,3 @@ In the following slides we will see declarations like
 -   function definitions
 -   import declarations
 -   ...
-
-
-
-
-

--- a/tutorial/src/Motivation.lagda
+++ b/tutorial/src/Motivation.lagda
@@ -8,60 +8,68 @@ module Motivation where
 \end{code}
 -->
 
-About the tutorial
+About this tutorial
 ==================
 
 Goals
 
-- show what is Agda good for
-- teach Agda syntax and semantics
-- teach Agda programming skills
+- Show what Agda is good for
+- Teach Agda syntax and semantics
+- Teach Agda programming skills
 
 Features
 
-- slides: 1/3 examples, 1/3 explanation, 1/3 exercises
-- only (part of) secondary school mathematics is required
+- Slides: 1/3 examples, 1/3 explanation, 1/3 exercises
+- Only (part of) secondary school mathematics is required
 
-[*More about the tutorial*](About.html)
+[*More about this tutorial*](About.html)
 
 
 What is Agda good for?
 =====================
 
-**To utilize the capacity of computers in a reliable way.**
+**Utilize the capacity of the computers in a reliable way.**
 
-Target:  
+Targets:
 
-programming and mathematics;  
-formal definitions, theorems, proofs and algorithms
+- Joining programming and mathematics
+- Formal definitions, theorems, proofs, and algorithms
 
 
 Benefits of programming in Agda
 ===============================
 
--   **eliminating errors**
+-   **Elimination of errors**
+
     -   no runtime errors  
         Inevitable errors like I/O errors are handled, others are excluded by design.
     -   no non-productive infinite loops
--   **machine checked documentation**  
-    Any functional properties can be formalized and proved; proof checking is automatic.  
-    -   distinction between finite and infinite data like lists vs. streams
-    -   invariant properties of data like sorted list, balanced tree can be maintained
-    -   function properties like commutativity, associativity can be maintained
--   **exact interfaces**  
-    Formal specification can be given with the help of exact mathematical concepts like 
-    groups, rings, lattices, categories, ...
--   **safe optimization**
-    -   runtime checks like array index bounds checks are eliminated
-    -   defensive coding (generous on input, strict on output) is unnecessary -- no overhead of it
-    -   safe optimization on special input like associative input function of a higher order function
--   **high level programming**
-    -   programming with types as data (generic programming, universes)  
-        Type may depend on runtime value and still checked in compile time.
-    -   reflection
-    -   Previously unseen range of embedded domain specific languages
-        can be defined with arbitrary precision.
 
+-   **Machine-checked documentation**  
+
+    -   any functional properties can be formalized and proved -- proof checking is automatic
+    -   distinction between finite and infinite data like lists vs. streams
+    -   invariant properties of data like sorted lists and balanced trees can be maintained
+    -   function properties like commutativity, associativity can be maintained
+
+-   **Exact interfaces**  
+
+    Formal specification can be given with the help of exact mathematical concepts like 
+    groups, rings, lattices, categories, and so on.
+
+-   **Safe optimization**
+
+    -   runtime checks like array bounds checks are eliminated
+    -   defensive coding (generous on input, strict on output) is unnecessary -- there is no overhead of it
+    -   safe optimization on special input like associative input function of a higher-order function
+
+-   **High-level programming**
+
+    -   programming with types as data (generic programming, universes)  
+        Types may depend on values in run time and still checked in compile time.
+    -   reflection
+    -   previously unseen range of embedded domain-specific languages
+        can be defined with arbitrary precision
 
 
 Benefits of creating formal systems in Agda
@@ -69,26 +77,25 @@ Benefits of creating formal systems in Agda
 
 Definitions
 
--   classical, constructive and modal logical connectives are definable
+-   Classical, constructive, and modal logical connectives can be defined.
 
 Theorems
 
--   one can quantify over elements, properties,
-    properties of properties etc.  
-    (Agda has the strength of an infinite-order logic)
+-   One can quantify over elements, properties, properties of properties etc.  
+    (Agda has the strength of an infinite-order logic.)
 
 Proofs
 
 -   Automatic simplification of expressions gives the
     automatic part of proofs.  
-    In this way algorithms can be used during proofs.
--   automatic proof checking
+    This way algorithms can be used in proofs.
+-   Automatic proof checking.
 
 Additional features
 
--   inferred terms, implicit arguments
--   holes, interactive development
--   unicode characters, mixfix operators
+-   Inferred terms, implicit arguments.
+-   Holes, interactive development.
+-   Unicode characters, mixfix operators.
 
 
 
@@ -162,31 +169,36 @@ Additional features
 -->
 
 
-Benefits of completing the tutorial
+Benefits of completing this tutorial
 ==========
 
--   use Agda directly (you have to put more effort in learning Agda for this)
-    -   develop formal systems, use Agda during research
+After completing this tutorial, you will be able to:
+
+-   Use Agda directly (you have to put more effort in learning Agda for this)
+
+    -   develop formal systems, use Agda in research
     -   write high-assurance code  
         Note that the current compiler is not industrial-strength, libraries are missing,  
         solutions for individual problems are not worked out.
--   learn similar languages easier
+
+-   Learn similar languages easier
+
     -   most Haskell type system extensions are just special cases
         -   Haskell is a practical general-purpose programming language also used in industry.
+
     -   languages with similar goals: Coq, Idris, Epigram
         -   write formal proofs in Coq which is more mainstream
--   use the ideas presented here
+
+-   Use the ideas presented here
+
     -   have a better programming style / understanding in other languages
     -   steal the ideas
--   learn theory easier (will be more familiar for you)
+
+-   Learn related theoretical concepts easier (which will be more familiar for you)
+
     -   type theory
         -   dependent types
+
     -   constructive mathematics
     -   semantics of programming languages
         -   λ-calculus
-
-
-
-
-
-

--- a/tutorial/src/Sets/Enumerated.lagda
+++ b/tutorial/src/Sets/Enumerated.lagda
@@ -10,7 +10,7 @@ module Sets.Enumerated where
 The `Bool` set
 ==============
 
-Definition of `Bool` with two elements `true` and `false`:
+Consider the definition of `Bool` with two elements, `true` and `false`:
 
 \begin{code}
 data Bool : Set where
@@ -20,15 +20,16 @@ data Bool : Set where
 
 *Interpretation:*
 
- * `Bool`  is a `Set`
- * `true`  is a `Bool`
- * `false` is a `Bool`
- * there is nothing else which is `Bool`
- * `true` and `false` are different
+ * `Bool`  is a `Set`.
+ * `true`  is a `Bool`.
+ * `false` is a `Bool`.
+ * There is *nothing else* that is `Bool`.
+ * `true` and `false` are different values.
 
-It is because of the last two points that the syntax of the definition doesn't look like this:
+It is due to last two points that the syntax of the definition does not look
+like that:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 Bool  : Set
 true  : Bool
 false : Bool
@@ -37,29 +38,39 @@ false : Bool
 
 --------------------
 
--   `data` and `where` are keywords
--   `Set` is the set of sets (a constant)
--   ':' is pronounced "is a" or "type of", it has similar rule as '∈' in set theory.  
-    We do not use the '∈' symbol because ':' and '∈' have different behaviour which will be highlighted later.
--   Indentation matters!
--   Spaces are needed!
--   We call `true` and `false` _constructors_ of _data type_ `Bool` (more explanations of constructors come later)
+Note that:
+
+-   The `data` and the `where` are keywords.
+
+-   The `Set` is the set of sets (a constant).
+
+-   The ':' is pronounced "is a" or "type of", it has similar rule as '∈'
+    in set theory.  We do not use the '∈' symbol because ':' and '∈' have
+    different meanings which will be discussed in details later.
+
+-   Indentation matters.
+
+-   Spaces matter.
+
+-   We call `true` and `false` _constructors_ of the _data type_ `Bool`
+    (more explanation on constructors will come later).
 
 
- 
+
 Exercises
-=========
+---------
 
-A) Define a set named `Answer` with three elements, `yes`, `no` and `maybe`.
+1. Define a set named `Answer` with only three elements: `yes`, `no`, and
+   `maybe`.
 
-B) Define a set named `Quarter` with four elements, `east`, `west`, `north` and `south`.
-
+1. Define a set named `Direction` with only four elements: `east`, `west`,
+   `north`, and `south`.
 
 
 Questions
 ===============
 
-Suppose we have `Bool'` defined:
+Consider the following definition of `Bool'`:
 
 \begin{code}
 data Bool' : Set where
@@ -67,7 +78,8 @@ data Bool' : Set where
   false' : Bool'
 \end{code}
 
-1.  Are `Bool` and `Bool'` the same sets?  
+1.  Are `Bool` and `Bool'` the same sets?
+
 1.  If not, which one is the "real" set of Booleans?
 
 
@@ -94,15 +106,15 @@ Interpretation (or meaning) is the opposite relation to representation.
 Special finite sets
 ===========
 
-We can define finite sets with n = 0, 1, 2, ... elements.
+We can define finite sets with $n = 0, 1, 2, \ldots$ elements.
 
-The special case with n = 0 is the empty set:
+The special case with $n = 0$ is the empty set:
 
 \begin{code}
-data ⊥ : Set where   -- There is no constructor.
+data ⊥ : Set where   -- Note that there is no constructor at all.
 \end{code}
 
-The special case with n = 1 is the singleton set (set with one element):
+The special case with $n = 1$ is the singleton set (a set with one element):
 
 \begin{code}
 data ⊤ : Set where
@@ -117,26 +129,33 @@ Types vs. sets
 
 Basic differences between types and sets:
 
--   The type of an element is unique ↔ an element can be member of different sets  
-    E.g. `true` cannot be the element of two different types at the same time.
--   A type is not the collection of its elements ↔ a set is characterized by its elements  
-    E.g. there are different empty types.
+-   The type of an element is unique ↔ an element can be member of different
+    sets.  E.g. `true` cannot be the element of two different types at the
+    same time.
 
-`data` defines types, not sets!  
+-   A type is not just the collection of its elements ↔ a set is characterized
+    by its elements.  E.g. there are different empty types.
+
+Thus `data` defines *types*, not sets.
 
 -   We prefer types over sets for several reasons.
--   From now on, we use both terms 'type' and 'set' for types.  
-    We use the term 'element' for types too.
--   `Set` is the type of types, so it should be called `Type`.  
+
+-   From now on, we use both terms "type" and "set" for types.
+    We use the term "element" for types too.
+
+-   `Set` is the type of types, so it should be called `Type`.  However,
     Agda 2.3.2 and before (and probably after too) calls it `Set`.
--   Agda allows to give the same name to constructors of different types,  
-    if at each constructor application the type is unambiguous.
+
+-   Agda makes it possible to give the same name to the constructors of
+    different types -- but only if each constructor application remains
+    unambiguous that way.
 
 
 Syntactic abbreviation
 ======================
 
-If we have multiple elements of the same type we can define them in one line:
+If we have multiple elements of the same type, it is possible to define them
+in one line:
 
 \begin{code}
 data name : Set where

--- a/tutorial/src/Sets/Indexed.lagda
+++ b/tutorial/src/Sets/Indexed.lagda
@@ -2,8 +2,8 @@
 % Péter Diviánszky
 % 2013. 01.
 
-Imports
-=======
+Import list
+===========
 
 \begin{code}
 module Sets.Indexed where
@@ -17,9 +17,9 @@ open import Data.Nat      using (ℕ; zero; suc)
 
 
 `Fin`, family of finite sets
-===========
+============================
 
-We wish to define a `ℕ`-indexed family of sets `Fin` such
+We wish to define an `ℕ`-indexed family of sets `Fin` such
 that `Fin n` has exactly `n` elements.
 
 Given the definition of `Fin`, the following equivalences would hold:
@@ -36,10 +36,10 @@ n   Sets with n elements
 
 
 Definition of `Fin`
-==========
+===================
 
-`Fin` is a set *indexed with* a natural number  
-(we use `Fin` because this is not the final definition of `Fin`):
+`Fin` is a set *indexed with* a natural number (we use `Fin` because this is
+not the final definition of `Fin`):
 
 \begin{code}
 data Fin : ℕ → Set where
@@ -49,7 +49,7 @@ data Fin : ℕ → Set where
 
 The definition yields the statements
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 zero 0 : Fin 1
 zero 1 : Fin 2
 zero 2 : Fin 3
@@ -65,9 +65,9 @@ suc 4 (suc 3 (zero 2)) : Fin 5
 ...
 ~~~~~~~~~~~~~~~~~
 
-which can be rearranged as
+that could be rearranged as
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 zero 0 : Fin 1
 
 zero 1 : Fin 2
@@ -89,12 +89,13 @@ So we can conclude that `Fin n` has `n` distinct elements.
 
 
 Exercises
-=========
+---------
 
-*   Define a `Bool` indexed family of sets such that the set indexed by `false` contains
-    no elements and the set indexed by `true` contains one element!
-*   Define a `ℕ` indexed family of sets such that the sets indexed by even numbers contain
-    one element and the others are empty!
+1. Define a `Bool`-indexed family of sets such that the set indexed by `false`
+   contains no elements and the set indexed by `true` contains one element.
+
+1. Define an `ℕ`-indexed family of sets such that the sets indexed by even
+   numbers contain one element and the others are empty!
 
 <!--
 \begin{code}
@@ -109,19 +110,19 @@ data Even : ℕ → Set where --
 
 
 `Vec A n` ~ `A`^`n`^
-==========
+====================
 
 `Vec A n` is an `n`-tuple of elements of `A`:
 
 \begin{code}
 data Vec (A : Set) : ℕ → Set where
-  []  : Vec A zero
+  []   : Vec A zero
   cons : (n : ℕ) → A → Vec A n → Vec A (suc n)
 \end{code}
 
-Examples:
+*Examples:*
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 [] : Vec ℕ 0
 [] : Vec Bool 0
 ...
@@ -136,11 +137,11 @@ cons 1 false (cons 0 true []) : Vec Bool 2
 
 
 Exercise
-========
+--------
 
-*   Define a `Bool` indexed family of sets with two parameters, `A` and `B`, such
-    that the set indexed by `false` contains
-    an `A` element and the set indexed by `true` contains a `B` element!
+Define a `Bool`-indexed family of sets with two parameters, `A` and `B`, such
+that the set indexed by `false` contains an `A` element and the set indexed by
+`true` contains a `B` element.
 
 <!--
 \begin{code}
@@ -149,4 +150,3 @@ data Union (A B : Set) : Bool → Set where  --
   inj₂ : B → Union A B true --
 \end{code}
 -->
-

--- a/tutorial/src/Sets/Mutual.lagda
+++ b/tutorial/src/Sets/Mutual.lagda
@@ -3,49 +3,58 @@
 \begin{code}
 module Sets.Mutual where
 
-open import Data.Bool using (Bool; true; false)
-open import Data.Nat using (ℕ; zero; suc)
+open import Sets.Enumerated using (Bool; true; false)
+open import Syntax.Decimal_Naturals using (ℕ; zero; suc)
 \end{code}
 
 
 Mutual definitions
 =========
 
-To allow mutual definitions one should declare any set before using it:
+In order to allow mutual definitions, one should declare any `Set` before
+using it.  Those are called "forward declarations" &mdash; they are not unique
+to Agda.
+
+Consider the following example for this:
 
 \begin{code}
+-- forward declarations
 data L : Set
 data M : Set
 
+-- actual declarations
 data L where
   nil : L
   _∷_ : ℕ → M → L
 
 data M where
-  _∷_ : Bool → L → M
+  _TT∷_ : Bool → L → M
 \end{code}
 
-Note that `: Set` is missing in the definitions of sets declared before.
+Note that `: Set` is missing from the definitions of the forward-declared
+sets.
 
-*Exercise*: What are the elements of `L` and `M`?
+Exercises
+---------
 
+#. What are the elements of `L` and `M`?
 
+#. Define trees where each node can have arbitrary (finite) number of children
+   (such as 0, 1, 2, and so on).
 
+#. Define a language by the following grammar in Agda:
 
-Exercise
-=========
+     $E \to B$  
+     $E \to I$  
+     $I \to I + I$  
+     $I \to I - I$  
+     $I \to I * I$  
+     $I \to z$  
+     $I \to s I$  
+     $B \to t$  
+     $B \to f$  
+     $B \to E = E$  
+     $B \to E ≠ E$  
 
-*   Define trees where each node can have any finite number of children
-    (0, 1, 2, ...).
-
-Exercise
-=========
-
-
-Define a small grammar!*
-
--------
-
-*highly underspecified exercise
-
-
+#. As a constant, give an element of the language defined in the previous
+   exercise that contains the application of every rule at least once.

--- a/tutorial/src/Sets/Parameters_vs_Indices.lagda
+++ b/tutorial/src/Sets/Parameters_vs_Indices.lagda
@@ -7,7 +7,7 @@ module Sets.Parameters_vs_Indices where
 \end{code}
 
 
-Import List
+Import list
 ===========
 
 \begin{code}
@@ -28,76 +28,77 @@ Parameters vs. indices
 
 The *first* index can be turned into a new parameter if
 each constructor has the same variable on the first index position
-(in the result type).
+(that is, in the result type).
 
-**Example 1**
+*Example 1.*
 
-~~~~~~ 
+~~~~~~
 data _≤′_ : ℕ → ℕ → Set where
   ≤′-refl : {m : ℕ} →                       m ≤′ m
   ≤′-step : {m : ℕ} → {n : ℕ} →  m ≤′ n  →  m ≤′ suc n
 ~~~~~~
 
-is similar to
+which is similar to
 
-~~~~~~ 
+~~~~~~
 data _≤′_ (m : ℕ) : ℕ → Set where
   ≤′-refl :                       m ≤′ m
   ≤′-step : {n : ℕ} →  m ≤′ n  →  m ≤′ suc n
 ~~~~~~
 
 
-**Example 2**
+*Example 2.*
 
-~~~~~~ 
+~~~~~~
 data _≤″_ : ℕ → ℕ → Set where
   ≤+ : ∀ {m n k} → m + n ≡ k → m ≤″ k
 ~~~~~~
 
-is similar to
+which is similar to
 
-~~~~~~ 
+~~~~~~
 data _≤″_ (m : ℕ) : ℕ → Set where
   ≤+ : ∀ {n k} → m + n ≡ k → m ≤″ k
 ~~~~~~
 
 which is similar to
 
-~~~~~~ 
+~~~~~~
 data _≤″_ (m : ℕ) (k : ℕ) : Set where
   ≤+ : ∀ {n} → m + n ≡ k → m ≤″ k
 ~~~~~~
 
 **Design decision**
 
-A parameter instead of an index is always a better choice
+It is always a better to use a parameter instead of an index, because:
 
-*   We state more about the structure of the set.*  
-    In turn, the Agda compiler can infer more properties of the set.**
-*   Cleaner syntax: each constructor has one parameter less.  
+*   We suggest more about the structure of the set.*  In turn, the Agda compiler
+    can infer more properties of this set.**
+
+*   Cleaner syntax: each constructor has one parameter less.
 
 *********************
 
-*The parameter can be fixed to get a simpler definition, for example
+*The parameter can be fixed in order to get a simpler definition, c.f.
 
-~~~~~~ 
+~~~~~~
 data 10≤′ : ℕ → Set where
   10≤′-refl :                       10≤′ 10
   10≤′-step : {n : ℕ} →  10≤′ n  →  10≤′ suc n
 ~~~~~~
 
-was made from `_≤′_` with a simple substitution which is possible with `_≤_`.
+was made from `_≤′_` with a simple substitution, which is possible with `_≤_`.
 
-**TODO: give examples.
-
-
-Parameters vs. indices (2)
-======================
-
-The parameters of the set are present as implicit arguments in the constructors.
-
-TODO 
-
+<!--
+|**TODO: give examples.
+|
+|Parameters vs. indices (2)
+|======================
+|
+|The parameters of the set are present as implicit arguments in the constructors.
+|
+|TODO
+-->
 
 <!--
 | A simpler definition
@@ -137,8 +138,10 @@ TODO
 | \end{code}
 -->
 
-General equality: `_≡_`
-================
+Generic equality: `_≡_`
+=======================
+
+Consider the following definition
 
 \begin{code}
 data  _≡_ {A : Set} (x : A) : A → Set  where
@@ -147,16 +150,16 @@ data  _≡_ {A : Set} (x : A) : A → Set  where
 infix 4 _≡_
 \end{code}
 
-yields
+that yields the following judgements:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 refl {ℕ} {0} : 0 ≡ 0
 refl {ℕ} {1} : 1 ≡ 1
 refl {ℕ} {2} : 2 ≡ 2
 ...
 ~~~~~~~~~~~~~~~~~
 
-so it represents equality!
+so we can come the conclusion that it actually represents equality.
 
 <!--
 | *Examples:*
@@ -181,27 +184,30 @@ so it represents equality!
 -->
 
 `_∈_` proposition
-===============
+=================
 
-Another parametric definition:
+Consider another parametric definition:
 
 \begin{code}
 data _∈_ {A : Set}(x : A) : List A → Set where
-  first : ∀ {xs} → x ∈ x ∷ xs
-  later : ∀ {y xs} → x ∈ xs → x ∈ y ∷ xs
+  first : ∀ {xs}   → x ∈ x ∷ xs
+  next  : ∀ {y xs} → x ∈ xs → x ∈ y ∷ xs
 
 infix 4 _∈_
 \end{code}
 
 
 Exercises
-=========
+---------
 
-*   Define `_⊆_ {A : Set} : List A → List A → Set`!
-    *   Prove that `1 ∷ 2 ∷ [] ⊆ 1 ∷ 2 ∷ 3 ∷ []`!
-    *   Prove that `1 ∷ 2 ∷ 3 ∷ [] ⊆ 1 ∷ 2 ∷ []` is false!
-*   Define a permutation predicate!
-*   Define a sort predicate!
+1. Define `_⊆_ {A : Set} : List A → List A → Set`.
+
+    * Prove that `1 ∷ 2 ∷ [] ⊆ 1 ∷ 2 ∷ 3 ∷ []`.
+    * Prove that `1 ∷ 2 ∷ 3 ∷ [] ⊆ 1 ∷ 2 ∷ []` is false.
+
+1. Define a predicate for permutations.
+
+1. Define a predicate for sorting.
 
 <!--
 \begin{code}
@@ -221,6 +227,4 @@ e1 =  keep (keep (drop stop)) --
 
 ***************
 
-You can type `⊆` as `\sub=`.
-
-
+Note that you can type `⊆` as `\sub=`.

--- a/tutorial/src/Sets/Parametric.lagda
+++ b/tutorial/src/Sets/Parametric.lagda
@@ -171,9 +171,7 @@ Set                     1st,                           2nd,                     
 `x : Square ℕ`  
 `x = suc (suc (zero (t4 (t4 1 2 3 4) (t4 5 6 7 8) (t4 9 10 11 12) (t4 13 14 15 16))))`
 
-~~~~~~~ {.latex}
-\left(\begin{array}{cccc}1&2&5&6\\3&4&7&8\\9&10&13&14\\11&12&15&16\end{array}\right)
-~~~~~~~
+$\left(\begin{array}{cccc}1&2&5&6\\3&4&7&8\\9&10&13&14\\11&12&15&16\end{array}\right)$
 
 ***************
 

--- a/tutorial/src/Sets/Parametric.lagda
+++ b/tutorial/src/Sets/Parametric.lagda
@@ -3,8 +3,7 @@
 % 2011. 09. 15.
 
 
-
-Import List
+Import list
 ===========
 
 \begin{code}
@@ -14,7 +13,7 @@ open import Data.Nat
 
 
 Definition of `List`
-==============
+====================
 
 Definition of `List`:
 
@@ -26,9 +25,11 @@ data List (A : Set) : Set where
 infixr 5 _∷_
 \end{code}
 
-*Interpretation*: `List A` ∈ `Set`, where `A` ∈ `Set`. We call `A` a parameter of `List` and we can refer to `A` in the definition of the set elements.
+*Interpretation*: `List A` ∈ `Set`, where `A` ∈ `Set`. We call `A` a
+parameter of `List` and we can refer to `A` in the definition of the set
+elements.
 
-*Example:* elements of `List Bool`:
+*Example:* Note that the elements of `List Bool` are as follows:
 
     []  
     true  ∷ []  
@@ -40,22 +41,18 @@ infixr 5 _∷_
     ...
 
 
-
-
-
 Exercises
-=========
+---------
 
-* What is the connection between `List ⊤` and `ℕ`?
-* Define a `Maybe` set (lists with 0 or 1 elements)!
-* Define parametric trees (various sorts)!
+1. What is the connection between `List ⊤` and `ℕ`?
+1. Define a `Maybe` set (lists with 0 or 1 elements).
+1. Define parametric trees (various sorts).
 
 
-
-`_×_`: Cartesian Product
+`_×_`: Cartesian product
 ========================
 
-The definition of Cartesian product:
+Definition of Cartesian product:
 
 \begin{code}
 data _×_ (A B : Set) : Set where
@@ -65,26 +62,28 @@ infixr 4 _,_
 infixr 2 _×_
 \end{code}
 
-`(A B : Set)` is the way of specifying a set that is parameterised by two sets.
+`(A B : Set)` is the way of specifying a set that is parameterized by two
+(other) sets.
 
-*Example:*  
-Elements of `Bool × Bool` (the extra space is needed before the comma):
+*Example:* Elements of `Bool × Bool` (the extra space is needed before
+the comma):
 
-     true , true 
+     true , true
      true , false
      false , true
      false , false
 
 
 Exercises
-=========
+---------
 
- * How many elements are there in `⊤ × ⊤`, `⊤ × ⊥`, `⊥ × ⊤` and `⊥ × ⊥`?
- * How should we define `Top` so that ∀ A : Set. `Top × A` would be isomorphic to `A` (neutral element of `_×_`)?
+1. How many elements are there in `⊤ × ⊤`, `⊤ × ⊥`, `⊥ × ⊤` and `⊥ × ⊥`?
+1. How should we define `Top` so that ∀ A : Set .`Top × A` would be
+   isomorphic to `A` (i.e. neutral element of `_×_`)?
 
 
-`_⊎_`: Disjoint Union (Sum)
-===================================
+`_⊎_`: Disjoint union (sum)
+===========================
 
 Definition:
 
@@ -98,13 +97,14 @@ infixr 1 _⊎_
 
 
 Exercises
-=========
+---------
 
- * What are the elements of `Bool ⊎ ⊤`?
- * What are the elements of `⊤ ⊎ (⊤ ⊎ ⊤)`?
- * Name an already learned isomorphic type to `⊤ ⊎ ⊤`!
- * How should we define `Bottom` so that ∀ A : Set. `Bottom ⊎ A` would be isomorphic to `A` (Neutral element of `_⊎_`)?
- * Give an isomorphic definition of `Maybe A` with the help of `_⊎_` and `⊤`!
+1. What are the elements of `Bool ⊎ ⊤`?
+1. What are the elements of `⊤ ⊎ (⊤ ⊎ ⊤)`?
+1. Name a type isomorphic to `⊤ ⊎ ⊤` that you have already seen before.
+1. How should we define `Bottom` so that ∀ A : Set . `Bottom ⊎ A` would
+   be isomorphic to `A` (i.e. neutral element of `_⊎_`)?
+1. Give an isomorphic definition of `Maybe A` with the help of `_⊎_` and `⊤`.
 
 
 Mutually recursive sets
@@ -124,7 +124,10 @@ data List₂ (A B : Set) where
   _∷_ : B → List₁ A B → List₂ A B
 \end{code}
 
-*Exercise:* list the smallest first 7 elements of `List₁ ⊤ Bool`!
+Exercise
+--------
+
+List the smallest first 7 elements of `List₁ ⊤ Bool`!
 
 
 Non-regular recursive set
@@ -138,24 +141,29 @@ data AlterList (A B : Set) : Set  where
   _∷_ : A → AlterList B A → AlterList A B
 \end{code}
 
+
+Exercise
+--------
+
 List the 4 smallest elements of `AlterList ⊤ Bool`, and
 the 5 smallest elements of `AlterList Bool ⊤`.
+
 
 Nested set
 ==========
 
 `Square`, the set of square matrices with 2^n^ rows, is nested, because at least
 one of its constructors refers to the set defined with more complex
-parameter(s):
+parameters:
 
 
 \begin{code}
 data T4 (A : Set) : Set where
-  quad : A → A → A → A → T4 A
+  t4 : A → A → A → A → T4 A
 
 data Square (A : Set) : Set where
   zero :            A  → Square A   -- 2^0 rows
-  suc  : Square (T4 A) → Square A   -- 2^(n+1) rows
+  suc  : Square (T4 A) → Square A   -- 2^(n + 1) rows
 \end{code}
 
 
@@ -175,10 +183,5 @@ $\left(\begin{array}{cccc}1&2&5&6\\3&4&7&8\\9&10&13&14\\11&12&15&16\end{array}\r
 
 ***************
 
-Nested sets are special non-regular sets.  
-Nested sets can be translated to mutually recursive regular sets.
-
-
-
-
-
+Nested sets are special non-regular sets.  Nested sets can be translated
+to mutually recursive regular sets.

--- a/tutorial/src/Sets/Propositions.lagda
+++ b/tutorial/src/Sets/Propositions.lagda
@@ -3,8 +3,8 @@
 % 2011. 05. 03., 2013. 01.
 
 
-Imports
-========
+Import list
+===========
 
 \begin{code}
 module Sets.Propositions where
@@ -16,11 +16,11 @@ open import Data.Nat using (ℕ; zero; suc)
 Proofs as data
 ==============
 
-It is beneficial to represent proofs as ordinary data;
-we can manipulate them like natural numbers.  
+It is beneficial to represent proofs as ordinary data &mdash;
+we can manipulate them like natural numbers.
 The proofs of each proposition will have a distinct type.
 
-We represent the proofs of the **true proposition** by the type `⊤`.  
+We represent the proofs of the **true proposition** by the type `⊤`.
 The true proposition has a trivial proof: `tt` (trivially true).
 
 \begin{code}
@@ -28,15 +28,16 @@ data ⊤ : Set where
   tt : ⊤
 \end{code}
 
-We represent the proofs of the **false proposition** by the type `⊥`.  
-The false proposition has no proofs (it cannot be proven).
+We represent the proofs of the **false proposition** by the type `⊥`.
+False proposition have no proofs (thus they cannot be proven).
 
 \begin{code}
 data ⊥ : Set where
 \end{code}
 
-We represent the proofs of the **conjunction** of two propositions `A` and `B` by the type `A × B`.  
-`A × B` has proofs of form `a , b` where `a` is a proof of `A` and `b` is a proof of `B`.
+We represent the proofs of the **conjunction** of two propositions `A` and
+`B` by the type `A × B`.  `A × B` has proofs of form `a , b` where `a` is a
+proof of `A` and `b` is a proof of `B`.
 
 \begin{code}
 data _×_ (A B : Set) : Set where
@@ -46,8 +47,8 @@ infixr 4 _,_
 infixr 2 _×_
 \end{code}
 
-We represent the proofs of the **disjunction** of two propositions `A` and `B` by the type `A ⊎ B`.  
-`A ⊎ B` has two different kinds of proofs:
+We represent the proofs of the **disjunction** of two propositions `A` and
+`B` by the type `A ⊎ B`.  `A ⊎ B` has two different kinds of proofs:
 
 *   `inj₁ a`, where `a` is proof of `A`,
 *   `inj₂ b`, where `b` is proof of `B`.
@@ -74,7 +75,7 @@ Construct one proof for each proposition if possible:
 -   `⊥ ⊎ ⊥`
 -   `⊥ ⊎ ⊤ ⊎ ⊤ × (⊥ ⊎ ⊥) ⊎ ⊤`
 
-Example:
+For example:
 
 \begin{code}
 ⊤×⊤ : ⊤ × ⊤
@@ -85,18 +86,20 @@ Example:
 Remarks
 =======
 
-We represent implication, negation, universal and existential quantification later.
+We will discuss the representation of implication, negation, universal, and
+existential quantification later.
 
-`_⊎_` represents *constructive* disjunction,
-we represent classical disjunction later and compare them.
+Note that `_⊎_` represents a *constructive* disjunction.  We are going to
+formalize the classical disjunction that way and compare the obtained
+concepts as we proceed.
 
 
 
 `_≤_`: Less-or-equal predicate
 ==========
 
-We wish to represent proofs of propositions n ≤ m (n, m = 0, 1, ...).  
-For this we define a set indexed with two natural numbers:
+We wish to represent proofs of propositions n ≤ m (n, m = 0, 1, ...).  For this,
+we define a set indexed with two natural numbers:
 
 \begin{code}
 data  _≤_ : ℕ → ℕ → Set where
@@ -106,9 +109,9 @@ data  _≤_ : ℕ → ℕ → Set where
 infix 4 _≤_
 \end{code}
 
-This yields the statements
+This yields the following judgements:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 z≤n {0} : 0 ≤ 0
 z≤n {1} : 0 ≤ 1
 z≤n {2} : 0 ≤ 2
@@ -124,9 +127,9 @@ s≤s (s≤s (z≤n {2})) : 2 ≤ 4
 ...
 ~~~~~~~~~~~~~~~~~
 
-which means that the following propositions have proofs:
+that means that the following propositions have proofs:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 0 ≤ 0
 0 ≤ 1,  1 ≤ 1
 0 ≤ 2,  1 ≤ 2,  2 ≤ 2
@@ -135,86 +138,109 @@ which means that the following propositions have proofs:
 ~~~~~~~~~~~~~~~~~
 
 
-Notes
+Notes:
 
-*   The `z≤n` constructor yields the first column of statements.
-*   The `s≤s` constructor yields the successive columns of statements.
-*   `1 ≤ 0` is also a valid expression which denotes an empty set.
+*   The `z≤n` constructor yields the first column of judgements.
+*   The `s≤s` constructor yields the successive columns of judgements.
+*   `1 ≤ 0` is also a valid expression that denotes an empty set.
 
 
 Proving non-emptiness
-========
+=====================
 
-We can prove that a set is non-empty by giving an element  
-(remember the syntax of constant definition):
+We can prove that a set is non-empty if we can construct any of its elements
+(recall how constants may be defined):
 
 \begin{code}
-0≤1 : 1 ≤ 10
-0≤1 = s≤s z≤n
+1≤10 : 1 ≤ 10
+1≤10 = s≤s z≤n
 \end{code}
 
-*Exercise:* Prove that 3 ≤ 7!
+Exercise
+--------
 
+Prove that 3 ≤ 7.
 
 Proving emptiness
-================
+=================
 
-How can we prove that a set like `7 ≤ 3` is empty?
+How could we prove that a set like `7 ≤ 3` is empty?
 
-1.  If `7 ≤ 3` would be non-empty, all its elements would look like `s≤s x` where `x : 6 ≤ 2`.
+1.  If `7 ≤ 3` was non-empty, all its elements would look like `s≤s x` where `x : 6 ≤ 2`.
+
     *   `z≤n` yields an element in `0 ≤ n` and `0` ≠ `7`.
-1.  If `6 ≤ 2` would be non-empty, all its elements would look like `s≤s x` where `x : 5 ≤ 1`.
+
+1.  If `6 ≤ 2` was non-empty, all its elements would look like `s≤s x` where `x : 5 ≤ 1`.
+
     *   `z≤n` yields an element in `0 ≤ n` and `0` ≠ `6`.
-1.  If `5 ≤ 1` would be non-empty, all its elements would look like `s≤s x` where `x : 4 ≤ 0`.
+
+1.  If `5 ≤ 1` was non-empty, all its elements would look like `s≤s x` where `x : 4 ≤ 0`.
+
     *   `z≤n` yields an element in `0 ≤ n` and `0` ≠ `5`.
+
 1.  `4 ≤ 0` is empty.
+
     *   `z≤n` yields an element in `0 ≤ n` and `0` ≠ `4`.
     *   `s≤s` yields an element in `suc m ≤ suc n` and `suc n` ≠ `0`.
 
-Although we will discuss all the details later here we have a look at
-how can this chain of inference be given in Agda:*
+Although we will discuss all the details later, here we have a look at
+how this chain of inference could be given in Agda:*
 
 \begin{code}
 7≰3 : 7 ≤ 3 → ⊥
 7≰3 (s≤s (s≤s (s≤s ())))
 \end{code}
 
-*   `()` denotes a value in a trivially empty set.
+where `()` denotes a value in a trivially empty set.
 
-*Exercise:* prove that `4 ≤ 2` is empty!
+Exercise
+--------
 
-We can use an emptiness proof in another emptiness proof:
+Prove that `4 ≤ 2` is empty.
+
+Note that emptiness proofs can be used in other emptiness proofs:
 
 \begin{code}
 8≰4 : 8 ≤ 4 → ⊥
 8≰4 (s≤s x) = 7≰3 x
 \end{code}
 
-*   `x` is an arbitrary variable name.
+where `x` is an arbitrary variable name.
 
-*Question:* Guess what kind of code can be generated from emptiness proofs!
+Exercise
+--------
+
+Guess what kind of code can be generated from emptiness proofs.
 
 
 ***************************
 
-*`7 ≤ 3 → ⊥` denotes a function from `7 ≤ 3` to `⊥` so we prove that
-`7 ≤ 3` is empty by giving a function which maps `7 ≤ 3` to a trivially empty set.  
-During the function definition we show that `7 ≤ 3` has no element so the function is defined.  
-We discuss functions in detail later.
+*: `7 ≤ 3 → ⊥` denotes a function from `7 ≤ 3` to `⊥` so we are proving that
+`7 ≤ 3` is empty by giving a function that maps `7 ≤ 3` to a trivially empty
+set.  Here, we show that `7 ≤ 3` has no elements hence the function is defined.
+We are going to discuss functions in details later.
 
 
 Exercises
-=========
+---------
 
-*   Define an indexed set `_isDoubleOf_ : ℕ → ℕ → Set` such that `m isDoubleOf n` is non-empty iff `m` is the double of `n`!
-    *   Prove that `8 isDoubleOf 4` is non-empty!
-    *   Prove that `9 isDoubleOf 4` is empty!
-*   Define an indexed set `Odd : ℕ → Set` such that `odd n` is non-empty iff `n` is odd!
-    *   Prove that `Odd 9` is non-empty!
-    *   Prove that `Odd 8` is empty!
-*   Define `Even : ℕ → Set` and `Odd : ℕ → Set` mutually!
-*   Define equality `_≡_ : ℕ → ℕ → Set`!
-*   Define non-equality `_≠_ : ℕ → ℕ → Set`!
+1.  Define an indexed set `_isDoubleOf_ : ℕ → ℕ → Set` such that `m isDoubleOf n`
+    is non-empty iff (if and only if) `m` is the double of `n`.
+
+    *   Prove that `8 isDoubleOf 4` is non-empty.
+    *   Prove that `9 isDoubleOf 4` is empty.
+
+1.  Define an indexed set `Odd : ℕ → Set` such that `Odd n` is non-empty iff `n`
+    is odd.
+
+    *   Prove that `Odd 9` is non-empty.
+    *   Prove that `Odd 8` is empty.
+
+1.  Define `Even : ℕ → Set` and `Odd : ℕ → Set` mutually.
+
+1.  Define equality `_≡_ : ℕ → ℕ → Set`.
+
+1.  Define non-equality `_≠_ : ℕ → ℕ → Set`.
 
 <!--
 | Equality on `ℕ`
@@ -279,8 +305,10 @@ Exercises
 | \end{code}
 -->
 
-Alternative representation
+Alternative representation of `_≤_`
 ========
+
+Consider the following indexed type:
 
 \begin{code}
 data _≤′_ : ℕ → ℕ → Set where
@@ -290,9 +318,9 @@ data _≤′_ : ℕ → ℕ → Set where
 infix 4 _≤′_
 \end{code}
 
-yields
+that yields the following:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 ≤′-refl : 0 ≤ 0
 ≤′-step ≤′-refl : 0 ≤ 1
 ≤′-step (≤′-step ≤′-refl) : 0 ≤ 2
@@ -310,8 +338,8 @@ yields
 
 As with `ℕ` and `ℕ₂`,
 
-*   the structure of the `m ≤ n` and `m ≤′ n` set elements are different
-*   different representations are good for different tasks  
+*   the structure of the `m ≤ n` and `m ≤′ n` set elements are different,
+*   different representations are good for different tasks.
 
 <!--
 | Alternative Definition
@@ -414,7 +442,7 @@ All code on this slide is valid.
 
 Original definition:
 
-~~~~~~~~~~~ 
+~~~~~~~~~~~
 data  _≤_ : ℕ → ℕ → Set where
   z≤n : {n : ℕ} →                       zero  ≤ n
   s≤s : {m : ℕ} → {n : ℕ} →   m ≤ n  →  suc m ≤ suc n
@@ -422,15 +450,15 @@ data  _≤_ : ℕ → ℕ → Set where
 
 The arrows between typed variables are not needed (also in case of round parenthesis):
 
-~~~~~~~~~~~ 
+~~~~~~~~~~~
 data  _≤_ : ℕ → ℕ → Set where
   z≤n : {n : ℕ} →                     zero  ≤ n
   s≤s : {m : ℕ} {n : ℕ} →   m ≤ n  →  suc m ≤ suc n
 ~~~~~~~~~~~
 
-Typed variables with the same type can be contracted (also in case of round parenthesis):
+Typed variables with the same type can be merged (also in case of round parenthesis):
 
-~~~~~~~~~~~ 
+~~~~~~~~~~~
 data  _≤_ : ℕ → ℕ → Set where
   z≤n : {n : ℕ} →               zero  ≤ n
   s≤s : {m n : ℕ} →   m ≤ n  →  suc m ≤ suc n
@@ -438,7 +466,7 @@ data  _≤_ : ℕ → ℕ → Set where
 
 Inferable expressions can be replaced by an underscore:
 
-~~~~~~~~~~~ 
+~~~~~~~~~~~
 data  _≤_ : ℕ → ℕ → Set where
   z≤n : {n : _} →               zero  ≤ n
   s≤s : {m n : _} →   m ≤ n  →  suc m ≤ suc n
@@ -446,7 +474,7 @@ data  _≤_ : ℕ → ℕ → Set where
 
 Variables with inferred types can be introduced by `∀`:
 
-~~~~~~~~~~~ 
+~~~~~~~~~~~
 data  _≤_ : ℕ → ℕ → Set where
   z≤n : ∀ {n} →               zero  ≤ n
   s≤s : ∀ {m n} →   m ≤ n  →  suc m ≤ suc n
@@ -456,10 +484,9 @@ data  _≤_ : ℕ → ℕ → Set where
 `_+_≡_`: Addition predicate
 ==========
 
-We wish to give a definition which
-yields the infinite set of true propositions
+We wish to give a definition that yields an infinite set of true propositions:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 0 + 0 ≡ 0,  1 + 0 ≡ 1,  2 + 0 ≡ 2,  ...
 0 + 1 ≡ 1,  1 + 1 ≡ 2,  2 + 1 ≡ 3,  ...
 0 + 2 ≡ 2,  1 + 2 ≡ 3,  2 + 2 ≡ 4,  ...
@@ -468,16 +495,16 @@ yields the infinite set of true propositions
 
 The outline of the solution:
 
-~~~~~~~~~~~~~~~~~ 
-(n : ℕ)                        zero  + n ≡ n     -- yields the first column of statements
-(m : ℕ) (n : ℕ)  m + n ≡ k  →  suc m + n ≡ suc k -- yields the successive columns of statements
+~~~~~~~~~~~~~~~~~
+(n : ℕ)                        zero  + n ≡ n     -- yields the first column of judgements
+(m : ℕ) (n : ℕ)  m + n ≡ k  →  suc m + n ≡ suc k -- yields the successive columns of judgements
 ~~~~~~~~~~~~~~~~~
 
-Technical details of the solution  
-(nothing new but better to repeat):
+Technical details of the solution (nothing new but better to repeat!):
 
 *   We define the *set* `n + m ≡ k` for each `n : ℕ`, `m : ℕ` and `k : ℕ`.  
     (`2 + 2 ≡ 5` is a valid set too.)
+
 *   The set `n + m ≡ k` will be non-empty iff `n` + `m` = `k`.  
     (`2 + 2 ≡ 4` is non-empty, `2 + 2 ≡ 5` is empty.)
 
@@ -485,7 +512,7 @@ Technical details of the solution
 Definition of `_+_≡_`
 ==========
 
-`_+_≡_` is an indexed set with three natural number indices and with two constructors:*
+`_+_≡_` is an indexed set with three natural number indices and two constructors:*
 
 \begin{code}
 data _+_≡_ : ℕ → ℕ → ℕ → Set where
@@ -493,9 +520,9 @@ data _+_≡_ : ℕ → ℕ → ℕ → Set where
   sns : ∀ {m n k} → m + n ≡ k → suc m + n ≡ suc k
 \end{code}
 
-which yields the statements
+that yields the following judgements:
 
-~~~~~~~ 
+~~~~~~~
 znn : 0 + 0 ≡ 0
 znn : 0 + 1 ≡ 1
 znn : 0 + 2 ≡ 2
@@ -511,26 +538,37 @@ sns (sns znn) : 2 + 2 ≡ 4
 ...
 ~~~~~~~
 
-Notes
-
-*   Underscores in `_+_≡_` denote the space for the operands (mixfix notation).
-
+Note that the underscores in `_+_≡_` denote the space for the operands
+(i.e. mixfix notation).
 
 *******************
 
-*this is the same as
+*:  That is the same as follows:
 
-~~~~~~~ 
+~~~~~~~
 data _+_≡_ : ℕ → ℕ → ℕ → Set where
   znn : {n : ℕ} → zero + n ≡ n
-  sns : {m : ℕ} → {n : ℕ} → m + n ≡ k → suc m + n ≡ suc k
+  sns : {m : ℕ} → {n : ℕ} → {k : ℕ} → m + n ≡ k → suc m + n ≡ suc k
 ~~~~~~~
 
 Exercises
-========
+---------
 
-*   Prove that 5 + 5 = 10!
-*   Prove that 2 + 2 ≠ 5!
+1. Prove that 5 + 5 = 10.
+
+1. Prove that 2 + 2 ≠ 5.
+
+1. Define `_⊓_≡_ : ℕ → ℕ → ℕ → Set` such that `m ⊓ n ≡ k` iff `k` is the minimum of
+   `m` and `n`.
+
+    *   Prove that both `3 ⊓ 5 ≡ 3` and `5 ⊓ 3 ≡ 3` are non-empty.
+    *   Prove that `3 ⊓ 5 ≡ 5` is empty.
+
+1. Define `_⊔_≡_ : ℕ → ℕ → ℕ → Set` such that `m ⊔ n ≡ k` iff `k` is the maximum of
+   `m` and `n`.
+
+    *   Prove that `3 ⊔ 5 ≡ 5` is non-empty.
+    *   Prove that `3 ⊔ 5 ≡ 3` is empty.
 
 <!--
 \begin{code}
@@ -542,31 +580,19 @@ Exercises
 \end{code}
 -->
 
-Exercises
-=========
+Reusing definitions
+===================
 
-*   Define `_⊓_ : ℕ → ℕ → Set` such that `n ⊓ m ≡ k` iff `k` is the minimum of `n` and `m`!
-    *   Prove that `3 ⊓ 5 ≡ 3` is non-empty!
-    *   Prove that `3 ⊓ 5 ≡ 5` is empty!
-*   Define `_⊔_ : ℕ → ℕ → Set` such that `n ⊔ m ≡ k` iff `k` is the maximum of `n` and `m`!
-    *   Prove that `3 ⊔ 5 ≡ 5` is non-empty!
-    *   Prove that `3 ⊔ 5 ≡ 3` is empty!
-
-
-
-Definition reuse
-================
-
-Another definition of `_≤_`:
+Consider another definition of the `_≤_` type:
 
 \begin{code}
 data _≤″_ : ℕ → ℕ → Set where
   ≤+ : ∀ {m n k} → m + n ≡ k → m ≤″ k
 \end{code}
 
-which yields
+that yields the following:
 
-~~~~~~~~~ 
+~~~~~~~~~
 ≤+ znn : 0 ≤″ 0
 ≤+ znn : 0 ≤″ 1
 ≤+ znn : 0 ≤″ 2
@@ -582,32 +608,44 @@ which yields
 ...
 ~~~~~~~~~
 
-Notes
+Notes:
 
  * This representation of less-than-or-equal is similar to `_≤_`.
- * If we write `≤+ : ∀ {m n k} → m + n ≡ k → n ≤″ k` (use `n` instead of `m` at the end) we get a representation of less-than-or-equal similar to `_≤′_` on the previous slides.
+ * If we were to wrote `≤+ : ∀ {m n k} → m + n ≡ k → n ≤″ k` (that is, use
+   `n` instead of `m` at the end) we would get a representation of
+   less-than-or-equal similar to `_≤′_` on the previous slides.
 
 
 Exercises
-=========
+---------
 
-*   Define `_isDoubleOf_ : ℕ → ℕ → Set` on top of `_+_≡_`!
-    *   Prove that `8 isDoubleOf 4` is non-empty!
-    *   Prove that `9 isDoubleOf 4` is empty!
-*   Define `_*_≡_ : ℕ → ℕ → Set` with the help of `_+_≡_`!
-    *   Prove that `3 * 3 ≡ 9` is non-empty!
-    *   Prove that `3 * 3 ≡ 8` is empty!
-*   Define `_≈_ : ℕ → ℕ⁺ → Set` which represents the (canonical) isomorphism between `ℕ` and `ℕ⁺`!*
-    *   Prove that `5 ≈ double+1 (double one)` is non-empty!
-    *   Prove that `4 ≈ double+1 (double one)` is empty!
+1.  Define `_isDoubleOf_ : ℕ → ℕ → Set` atop `_+_≡_`.
+
+    *   Prove that `8 isDoubleOf 4` is non-empty.
+    *   Prove that `9 isDoubleOf 4` is empty.
+
+1.  Define `_*_≡_ : ℕ → ℕ → ℕ → Set` with the help of `_+_≡_`.
+
+    *   Prove that `3 * 3 ≡ 9` is non-empty.
+    *   Prove that `3 * 3 ≡ 8` is empty.
+
+1.  Define `_≈_ : ℕ → ℕ⁺ → Set` that represents the (canonical) isomorphism
+    between `ℕ` and `ℕ⁺`.*
+
+    *   Prove that `5 ≈ double+1 (double one)` is non-empty.
+    *   Prove that `4 ≈ double+1 (double one)` is empty.
+
+*Hint.*  Recall the definition of `ℕ⁺`, `one`, `double`, `double+1`:
+
+\begin{code}
+data ℕ⁺ : Set where
+  one      : ℕ⁺
+  double   : ℕ⁺ → ℕ⁺
+  double+1 : ℕ⁺ → ℕ⁺
+\end{code}
 
 <!--
 \begin{code}
-data ℕ⁺ : Set where  --
-  one    : ℕ⁺  --
-  double : ℕ⁺ → ℕ⁺ --
-  double+1 : ℕ⁺ → ℕ⁺ --
-
 module ℕ≈ℕ⁺ where --
 
   data _≈_ : ℕ → ℕ⁺ → Set where --
@@ -625,6 +663,5 @@ module ℕ≈ℕ⁺ where --
 
 *****************
 
-*There are lots of isomorphisms between `ℕ` and `ℕ⁺`, we mean here the most natural one.
-
-
+*: There are many isomorphisms between `ℕ` and `ℕ⁺`, here we are referring to the
+   most natural one.

--- a/tutorial/src/Sets/Recursive.lagda
+++ b/tutorial/src/Sets/Recursive.lagda
@@ -10,16 +10,18 @@ open import Data.Bool using (Bool; true; false)
 \end{code}
 
 The effect of this `open import` declaration is the same as if we copied the
-definition of `Bool` type here. Note that we enumerated the constructors of `Bool` too.
+definition of the `Bool` type here.  Note that we enumerated the constructors of
+`Bool` too.
 
-More about import declarations come later.
+More about import declarations will come later.
 
 
 Peano representation
 ============================
 
-We are looking for a representation natural numbers.
-The simplest choice is the *Peano representation* which corresponds to the unary numeral system:
+We are looking for a representation for the natural numbers.
+The simplest choice is the *Peano representation* which corresponds to the
+unary numeral system:
 
 term                    interpretation in decimal form
 ----------------------- --------------------------
@@ -33,7 +35,7 @@ term                    interpretation in decimal form
 Definition of `ℕ`
 ==============
 
-In Agda the definition
+In Agda, the definition of natural numbers is as follows.
 
 \begin{code}
 data ℕ : Set where
@@ -41,9 +43,9 @@ data ℕ : Set where
   suc  : ℕ → ℕ
 \end{code}
 
-yields the infinite set of judgements
+Note that this definition yields the infinite set of judgements.
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 ℕ : Set
 zero : ℕ
 suc zero : ℕ
@@ -57,15 +59,18 @@ suc (suc (suc zero)) : ℕ
 -->
 
 
-Type-checking of expressions
+Type checking of expressions
 =======================
 
-With the Emacs command C-`c` C-`d` one can get Agda to type-check
+With the Emacs command C-`c` C-`d`, one can get Agda to type check
 a given expression (`d` stands for 'deduce').
 
-Example: Hit C-`c` C-`d` and enter `suc (suc zero)`. 
+Example: Hit C-`c` C-`d` and enter `suc (suc zero)`.
 
-Exercise: Try to type-check the following expressions:
+Exercises
+---------
+
+Deduce the type of the following expressions with Agda:
 
 -   `suc zero`
 -   `suc (zero)`
@@ -78,6 +83,8 @@ Exercise: Try to type-check the following expressions:
 Binary representation of `ℕ`
 ==============
 
+Consider the following definition of positive natural numbers, labelled as ℕ⁺:
+
 \begin{code}
 data ℕ⁺ : Set where
   one      :      ℕ⁺
@@ -85,7 +92,8 @@ data ℕ⁺ : Set where
   double+1 : ℕ⁺ → ℕ⁺
 \end{code}
 
-yields (without ordering)
+Note that this definition above yields the following judgements
+(without ordering):
 
 ~~~~~~~~~~~~~~~~~ 
 ℕ⁺ : Set
@@ -129,7 +137,8 @@ id (double+1 (double one)) : ℕ₂
 -->
 
 
-Soon we will prove in Agda that `ℕ` and `ℕ₂` are isomorphic with the following relation:
+Soon we will prove in Agda that `ℕ` and `ℕ₂` are isomorphic with the following
+relation:
 
 **ℕ**                   **ℕ₂**
 ----------------------- --------------------------
@@ -139,9 +148,13 @@ Soon we will prove in Agda that `ℕ` and `ℕ₂` are isomorphic with the follo
 `suc (suc (suc zero))`  `id (double+1 one)`
 ...                     ...
 
-*Exercise:* How 9 is represented in `ℕ₂`? Type-check the expression!
+Exercises
+---------
 
-*Question*: why didn't we use one `data` definition with 4 constructors `zero`, `one`, `double`, `double+1`?
+1. How 9 is represented in `ℕ₂`?  Type check that expression.
+
+1. Why did not we simply use one `data` definition with 4 constructors,
+   such as `zero`, `one`, `double`, and `double+1`?
 
 
 
@@ -150,15 +163,18 @@ Rationale behind different representations
 
 Each representation has its merit.
 
-*Exercise:* Guess which representation (`ℕ` or `ℕ₂`) is better for the following tasks!
+Exercise
+--------
 
- * Computing `n * 2`.
- * Computing `⌊n / 2⌋`.
- * Deciding whether the number is odd.
- * Computing `n + m`.
- * Computing `n * m`.
- * Proving that `n + m` = `m + n` for all `m` and `n`.
- * Storing the number.
+Determine which representation (`ℕ` or `ℕ₂`) is better for the following tasks.
+
+ * Compute `n * 2`.
+ * Compute `⌊n / 2⌋`.
+ * Decide whether the number is odd.
+ * Compute `n + m`.
+ * Compute `n * m`.
+ * Prove that `n + m` = `m + n` for all `m` and `n`.
+ * Store a number.
 
 *****************
 
@@ -167,9 +183,9 @@ and convert values between different representations.
 
 
 Exercise
-=========
+--------
 
- * Define `ℤ`!
+Define `ℤ`.
 
 (Several solutions are possible.)
 
@@ -185,7 +201,7 @@ data BinTree : Set where
 
 yields
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 BinTree : Set
 leaf : BinTree
 node leaf leaf : BinTree
@@ -198,21 +214,26 @@ node (node leaf leaf) (node leaf leaf) : BinTree
 `BinTree` elements are good for representing binary trees (just the shapes without data).
 
 
-*Exercise:* define binary trees according to the following shapes!
+Exercise
+--------
+
+Define binary trees according to the following shapes.
 
 ![Binary tree shapes](dot/Binary_tree_shapes.gif)
 
 
 
 Exercises
-=========
+---------
 
-*   Define binary trees
+1.  Define binary trees
     -   with natural number data attached to the leafs
     -   with natural number data attached to the nodes
     -   with Booleans in the nodes and natural numbers in the leafs
-*   Define the lists (finite sequences) of natural numbers.
-*   Define the non-empty lists of natural numbers.
+
+1.  Define the lists (finite sequences) of natural numbers.
+
+1.  Define the non-empty lists of natural numbers.
 
 
 

--- a/tutorial/src/Sets/Sigma.lagda
+++ b/tutorial/src/Sets/Sigma.lagda
@@ -5,7 +5,7 @@ module Sets.Sigma where
 \end{code}
 
 
-Import List
+Import list
 ===========
 
 \begin{code}
@@ -17,7 +17,6 @@ open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat using (ℕ; zero; suc; _<_; s≤s; z≤n)
 open import Data.Unit using (⊤; tt)
 open import Data.Product using (_×_; _,_)
-open import Function using (_$_; _∘_)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
 open import Data.Empty using (⊥)
 \end{code}
@@ -39,23 +38,23 @@ infixr 4 _,_
 Usage
 =====
 
-The dependent pair may represent
+A dependent pair may represent:
 
--   disjoint union of a family of data types,
--   subset of a set,
+-   a disjoint union of a family of (data) types,
+-   a subset of a set,
 -   existential quantification.
 
 
 `Σ` as disjoint union
 =====================
 
-Examples:
+Some examples of where `Σ` could be used as disjoint union:
 
 -   `List A` ~ `Σ ℕ (Vec A)`
 -   `Σ ℕ Fin` is the type that contains all `Fin`s.
 
-The non-dependent pair and the disjoint union of two types are special cases
-of `Σ`:
+Note that the non-dependent pair and the disjoint union of two types are
+special cases of `Σ`:
 
 -   `A × B` ~ `Σ A (const B)`
 -   `A ⊎ B` ~ `Σ Bool (λ b → if b then A else B)`
@@ -64,20 +63,20 @@ of `Σ`:
 `Σ` as subset
 =============
 
-If `A` is a type and `P` is a predicate on `A`, then we can
-represent the set of elements which fulfil the predicate by `Σ A P`.
+If `A` is a type and `P` is a predicate on `A` then we could
+represent the set of elements that fulfill the predicate by `Σ A P`.
 
 Examples:
 
 -   `Vec A n`      ~ `Σ (List A) (λ l → length l ≡ n)`
--   `Fin n`        ~ `Σ ℕ        (λ m → m < n)`
--   balanced trees ~ `Σ` tree   `(λ t → t` is balanced`)`
+-   `Fin n`        ~ `Σ ℕ (λ m → m < n)`
+-   balanced trees ~ `Σ` tree `(λ t → t` is balanced`)`
 
 
 Exercise
-========
+--------
 
-Define `toFin`:
+Define the `toFin` function for the `Fin′` type.
 
 \begin{code}
 Fin′ : ℕ → Set
@@ -95,11 +94,11 @@ toFin (suc n , s≤s m≤n) = suc (toFin (n , m≤n))
 
 
 `Σ` as existential quantification
-==================================
+=================================
 
-Let `A` be a type and let `P` be a predicate on `A`.  
-There exists (constructively) an element of `A` for which `P` holds iff
-the subset `Σ A P` is nonempty.
+Let `A` be a type and let `P` be a predicate on `A`.  There exists
+(constructively) an element of `A` for which `P` holds iff
+the subset `Σ A P` is non-empty.
 
 Examples:
 
@@ -108,44 +107,58 @@ Examples:
 -   `odd n` ~ `Σ ℕ (λ k → n ≡ 1 + 2 * k)`
 -   `a ∈ as` ~ `Σ ℕ (λ k → as ! k ≡ a)`
 
+Note that there we could interpret the `Σ A (λ x → P(x))` pattern as
+`∃ x ∈ A . P(x)`.
 
-Exercise
-========
 
-Sigma is very handy when a function needs to return a value and a proof that the value has some property.  
+Other use of `Σ`
+================
 
-Example:
+`Σ` can also be very handy when a function needs to return a value
+together with a proof of that the given value has some property.
+
+For example:
 
 \begin{code}
 data _∈_ {A : Set}(x : A) : List A → Set where
   first : {xs : List A} → x ∈ x ∷ xs
-  later : {y : A}{xs : List A} → x ∈ xs → x ∈ y ∷ xs
+  next  : {y : A}{xs : List A} → x ∈ xs → x ∈ y ∷ xs
 
 infix 4 _∈_
 
 _!_ : ∀{A : Set} → List A → ℕ → Maybe A
-[] ! _             = nothing
+[]       ! _       = nothing
 (x ∷ xs) ! zero    = just x
 (x ∷ xs) ! (suc n) = xs ! n
 
 infix 5 _!_
-
-lookup : ∀ {A}{x : A}(xs : List A) → x ∈ xs → Σ ℕ (λ n → (xs ! n) ≡ just x)
 \end{code}
 
-Define `lookup`!
+Exercise
+--------
+
+In connection to this example, define the `lookup` function:
+
+\begin{code}
+lookup : ∀ {A}{x : A}(xs : List A) → x ∈ xs → Σ ℕ (λ n → xs ! n ≡ just x)
+\end{code}
+
+*Hint:* Use the `with` keyword.
 
 <!--
 \begin{code}
 lookup []       ()
 lookup (x ∷ xs) first     = 0 , refl
-lookup (x ∷ xs) (later p) with lookup xs p
-lookup (_ ∷ _)  (later p) | n , q = suc n , q 
+lookup (x ∷ xs) (next p) with lookup xs p
+lookup (_ ∷ _)  (next p) | n , q = suc n , q
 \end{code}
 -->
 
 Exercise
-========
+--------
+
+Consider the following definitions that declare the isomorphism (known from
+earlier) between `List ⊤` and `ℕ`.
 
 \begin{code}
 fromList : List ⊤ → ℕ
@@ -156,21 +169,23 @@ toList : ℕ → List ⊤
 toList zero = []
 toList (suc n) = tt ∷ toList n
 
-lemm : ∀ {a b : ℕ} → Data.Nat.suc a ≡ Data.Nat.suc b → a ≡ b
-lemm refl = refl
+lemma : ∀ {a b : ℕ} → Data.Nat.suc a ≡ Data.Nat.suc b → a ≡ b
+lemma refl = refl
 
-from-injection : ∀ {a b} → fromList a ≡ fromList b → a ≡ b
+from-injection : ∀ {a b} → (fromList a) ≡ (fromList b) → a ≡ b
 from-injection {[]}      {[]}      refl = refl
 from-injection {[]}      {x ∷ xs}  ()
 from-injection {x ∷ xs}  {[]}      ()
-from-injection {tt ∷ xs} {tt ∷ ys} p = cong (_∷_ tt) $ from-injection {xs} {ys} (lemm p)
+from-injection {tt ∷ xs} {tt ∷ ys} p = cong (_∷_ tt) (from-injection {xs} {ys} (lemma p))
 \end{code}
 
-Define the following function:
+Now, define the following function:
 
 \begin{code}
-from-surjection : ∀ (n : ℕ) → Σ (List ⊤) (_≡_ n ∘ fromList)
+from-surjection : ∀ (n : ℕ) → Σ (List ⊤) (λ t → (fromList t) ≡ n)
 \end{code}
+
+*Hint:* Use the `with` keyword.
 
 <!--
 \begin{code}

--- a/tutorial/src/Sets/With_Functions.lagda
+++ b/tutorial/src/Sets/With_Functions.lagda
@@ -3,7 +3,7 @@
 \begin{code}
 module Sets.With_Functions where
 
-open import Data.Nat
+open import Data.Nat using (zero; suc; ℕ; _+_)
 open import Data.Empty using (⊥)
 open import Data.List using (List; length)
 open import Relation.Nullary using (Dec; yes; no)

--- a/tutorial/src/Sets/With_Functions.lagda
+++ b/tutorial/src/Sets/With_Functions.lagda
@@ -4,9 +4,9 @@
 module Sets.With_Functions where
 
 open import Data.Nat using (zero; suc; ℕ; _+_)
+open import Data.Bool
 open import Data.Empty using (⊥)
-open import Data.List using (List; length)
-open import Relation.Nullary using (Dec; yes; no)
+open import Data.List using (List; length; _∷_; [])
 open import Data.Product using (Σ; _×_; _,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; trans; sym; cong)
 \end{code}
@@ -15,7 +15,7 @@ open import Relation.Binary.PropositionalEquality using (_≡_; refl; trans; sym
 Types with function application in indices
 ==========================================
 
-The following two types are equivalent:
+Consider the following two types that are equivalent:
 
 \begin{code}
 data Even : ℕ → Set where
@@ -25,7 +25,7 @@ data Even′ (m : ℕ) : Set where
   double : ∀ n → m ≡ n + n → Even′ m
 \end{code}
 
-Conversion functions:
+There exist conversion functions between those types:
 
 \begin{code}
 toEven : ∀ {m} → Even′ m → Even m
@@ -39,95 +39,159 @@ toEven′ {.(n + n)} (double n) = double n refl
 Usage
 =====
 
-Although `Even` and `Even′` are equivalent, `Even′` is much easier to use.
+Although `Even` and `Even′` are equivalent, `Even′` is much easier to use.  In
+order to see this, let us try to prove that `Even n` is decidable for all `n`.
 
-To see this, try to prove that `Even n` is decidable for all `n`.
+The concept of "decidable" is modelled by the `Dec` set (we will discuss that
+later, just take a quick look at its definition for now):
 
+\begin{code}
+infix 3 ¬_
 
-Lemmas
-======
+¬_ : ∀ {A} → Set A → Set A
+¬ P = P → ⊥
+
+data Dec (A : Set) : Set where
+  yes :   A → Dec A
+  no  : ¬ A → Dec A
+\end{code}
+
+Lemmata
+=======
+
+Consider the following lemmata for the proofs:
 
 \begin{code}
 suc-+ : ∀ n m → suc (n + m) ≡ n + suc m
-suc-+ zero m = refl
+suc-+ zero    m = refl
 suc-+ (suc n) m = cong suc (suc-+ n m)
 
 prev-≡ : ∀ {n m} → suc n ≡ suc m → n ≡ m
 prev-≡ {.m} {m} refl = refl
 \end{code}
 
-
 Proof for `Even′`
-======
+=================
 
+With the help of the lemmata, the proof for `Even′` could be given as
+follows.  Note the use of a new construct, the `with` keyword in the
+function definitions.  This keyword is used to implement pattern matching
+on the value of the recursive invocation.
 
 \begin{code}
 nextEven′ : ∀ {n} → Even′ n → Even′ (suc (suc n))
 nextEven′ {.(n₁ + n₁)} (double n₁ refl)
-    = double (suc n₁) (cong suc (suc-+ n₁ n₁))
+  = double (suc n₁) (cong suc (suc-+ n₁ n₁))
 
 prevEven′ : ∀ {n} → Even′ (suc (suc n)) → Even′ n
 prevEven′ {m} (double zero ())
 prevEven′ {m} (double (suc n) x)
-    = double n (prev-≡ (trans (prev-≡ x) (sym (suc-+ n n))))
+  = double n (prev-≡ (trans (prev-≡ x) (sym (suc-+ n n))))
 
-¬Even′1 : Even′ 1 → ⊥
+¬Even′1 : ¬ (Even′ 1)
 ¬Even′1 (double zero ())
 ¬Even′1 (double (suc zero) ())
 ¬Even′1 (double (suc (suc n)) ())
 
 isEven′ : (n : ℕ) → Dec (Even′ n)
-isEven′ zero = yes (double zero refl)
+isEven′ zero       = yes (double zero refl)
 isEven′ (suc zero) = no ¬Even′1
-isEven′ (suc (suc n)) with isEven′ n
-isEven′ (suc (suc n)) | yes e = yes (nextEven′ e)
-isEven′ (suc (suc n)) | no ¬p = no (λ x → ¬p (prevEven′ x))
+isEven′ (suc (suc n)) with (isEven′ n)
+... | yes e = yes (nextEven′ e)
+... | no ¬p = no (λ x → ¬p (prevEven′ x))
 \end{code}
 
-
-Proof for `Even`
-======
-
-Now try to do the same for `Even`.
-
-`¬Even1` is possible only with a trick:
+Just for the sake of comparison, here is an example of using `with` in a
+regular function definition.
 
 \begin{code}
-¬Even1 : ∀ {n} → Even n → n ≡ 1 → ⊥
+filter : {A : Set} → (A → Bool) → List A → List A
+filter p [] = []
+filter p (x ∷ xs) with (p x)
+... | true  = x ∷ filter p xs
+... | false = filter p xs
+\end{code}
+
+The `rewrite` construct
+=======================
+
+If `x : a ≡ b`, it is also possible to write the following:
+
+~~~~{.agda}
+f params rewrite x = body
+~~~~~
+
+instead of that:
+
+~~~~{.agda}
+f params with a | x
+... | ._ | refl = body
+~~~~
+
+The `rewrite` construct has the effect of rewriting the goal and the
+context by the given equation (left to right).
+
+The function can be rewritten with using several equations (in sequence)
+by separating them with vertical bars (`|`):
+
+~~~~{.agda}
+f params rewrite x₁ | x₂ | … = body
+~~~~
+
+It is also possible to add with clauses after rewriting:
+
+~~~~{.agda}
+f params rewrite xs with x
+... | p = body
+~~~~
+
+Note that pattern matching happens before rewriting.  If you want to
+rewrite and then do pattern matching you can use a `with` after the
+rewrite.
+
+Proof for `Even`
+================
+
+Now try to construct the proof with using `Even`.  As part of this, we will
+soon come to the conclusion that `¬Even1` is only possible to prove when a
+trick is employed:
+
+\begin{code}
+¬Even1 : ∀ {n} → Even n → ¬ (n ≡ 1)
 ¬Even1 (double zero) ()
 ¬Even1 (double (suc zero)) ()
 ¬Even1 (double (suc (suc n))) ()
 \end{code}
 
-For `nextEven` we need rewriting (a new feature):
+For proving `nextEven`,  we will need to do a rewriting (see above):
 
 \begin{code}
 nextEven : ∀ {n} → Even n → Even (suc (suc n))
-nextEven {.(n₁ + n₁)} (double n₁) rewrite cong suc (suc-+ n₁ n₁) = double (suc n₁)
+nextEven {.(n₁ + n₁)} (double n₁) rewrite (cong suc (suc-+ n₁ n₁)) = double (suc n₁)
 \end{code}
 
-However, I could prove `prevEven` only with the help of `prevEven′` which demonstrates
-that `Even′` is easier to use:
+However, we could prove `prevEven` only with the help of `prevEven′` that
+demonstrates that `Even′` is actually easier to use:
 
 \begin{code}
 prevEven : ∀ {n} → Even (suc (suc n)) → Even n
-prevEven e = toEven (prevEven′ (toEven′ e)) 
+prevEven e = toEven (prevEven′ (toEven′ e))
 \end{code}
 
-`isEven` is similar to `isEven′`:
+Note that proving `isEven` is similar to proving `isEven′`:
 
 \begin{code}
 isEven : (n : ℕ) → Dec (Even n)
-isEven zero = yes (double zero)
+isEven zero       = yes (double zero)
 isEven (suc zero) = no (λ x → ¬Even1 x refl)
-isEven (suc (suc n)) with isEven n
-isEven (suc (suc n)) | yes e = yes (nextEven e)
-isEven (suc (suc n)) | no ¬p = no (λ x → ¬p (prevEven x))
+isEven (suc (suc n)) with (isEven n)
+... | yes e = yes (nextEven e)
+... | no ¬p = no (λ x → ¬p (prevEven x))
 \end{code}
 
 
-Other examples
-==============
+Further examples
+================
 
 \begin{code}
 data  _≤″_ : ℕ → ℕ → Set  where

--- a/tutorial/src/Syntax/Decimal_Naturals.lagda
+++ b/tutorial/src/Syntax/Decimal_Naturals.lagda
@@ -45,23 +45,19 @@ notations of constants in Peano representation:
       zero :     ℕ
       suc  : ℕ → ℕ
 
-    {-# BUILTIN NATURAL ℕ    #-}
-    {-# BUILTIN ZERO    zero #-}
-    {-# BUILTIN SUC     suc  #-}
+    {-# BUILTIN NATURAL ℕ #-}
 
 
-Unfortunately, this BUILTIN machinery is not designed to accommodate multiple
-definitions of a given BUILTIN.
+Unfortunately, this `BUILTIN` machinery is not designed to accommodate multiple
+definitions of a given `BUILTIN`.
 If we wish to use definitions from the Standard Libraries later (and we wish),
 we cannot make another Peano representation of naturals *with* decimal notation.
 
-The solution is to reuse the existing `ℕ`, `zero`, `suc` definitions
+The solution is to reuse the existing the `ℕ`, `zero`, and `suc` definitions
 with decimal notation from the Standard Libraries:
 
 \begin{code}
 open import Data.Nat public using (ℕ; zero; suc)
 \end{code}
 
-(`import` declarations are discussed later.)
-
-
+(Import declarations will be discussed later.)

--- a/tutorial/src/Syntax/Infix.lagda
+++ b/tutorial/src/Syntax/Infix.lagda
@@ -3,12 +3,14 @@
 \begin{code}
 module Syntax.Infix where
 
-open import Data.Bool using (Bool; true; false)
+open import Sets.Enumerated using (Bool; true; false)
 \end{code}
 
 
 Infix notation
 ==============
+
+Consider this definition:
 
 \begin{code}
 data BinTree' : Set where
@@ -16,9 +18,9 @@ data BinTree' : Set where
   _+_ : BinTree' → BinTree' → BinTree'
 \end{code}
 
-yields
+There one can note that it basically yields the following:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 BinTree' : Set
 x : BinTree'
 x + x : BinTree'
@@ -28,17 +30,21 @@ x + (x + x) : BinTree'
 ...
 ~~~~~~~~~~~~~~~~~
 
-Underscores in names like `_+_` denote the space for the operands.  
+Underscores in names &mdash; like `_+_` above &mdash; are placeholders for
+operands.
 
-One can give the precedence with `infix`, `infixl` or `infixr`:
+One can also give the precedence with `infix`, (non-associative),
+`infixl` (left-associative) or `infixr` (right-associative).
+
+For example the single line below:
 
 \begin{code}
 infixr 3 _+_
 \end{code}
 
-yields
+yields the following:
 
-~~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~~
 BinTree' : Set
 x : BinTree'
 x + x : BinTree'
@@ -48,6 +54,4 @@ x + x + x : BinTree'
 ...
 ~~~~~~~~~~~~~~~~~
 
-(so `_+_` has right precedence)
-
-
+(So, now `_+_` has the right precedence, and it became right-associative.)

--- a/tutorial/src/Term_Inference.lagda
+++ b/tutorial/src/Term_Inference.lagda
@@ -3,8 +3,8 @@
 % 2013. 01.
 
 
-Imports
-=======
+Import list
+===========
 
 \begin{code}
 module Term_Inference where
@@ -17,17 +17,17 @@ open import Data.Nat      using (ℕ; zero; suc)
 
 
 Term inference
-===========
+==============
 
-The Agda compiler tries to infer terms marked with underscore.  
-If the choice of term is ambiguous, term inference fails. 
+The Agda compiler tries to infer terms marked with underscore.  If the choice
+of term is ambiguous, the term inference will fail.
 
-Examples:
+*Examples:*
 
 \begin{code}
 data Fin′ : ℕ → Set where
-  zero : (n : _) → Fin′ (suc n)   -- ℕ is inferred
-  suc  : (n : _) → Fin′ n → Fin′ (suc n)   -- ℕ is inferred
+  zero : (n : _) → Fin′ (suc n)            -- ℕ is inferred
+  suc  : (n : _) → Fin′ n → Fin′ (suc n)   -- ℕ is inferred again
 
 x : Fin′ 3
 x = suc _ (zero _)   -- 2 and 1 are inferred
@@ -35,14 +35,14 @@ x = suc _ (zero _)   -- 2 and 1 are inferred
 
 ------------
 
-If term inference fails we see yellow colour.
+Term inference failure is marked with yellow colour.
 
 
 Implicit arguments
-==========
+==================
 
-Underscores can be hidden:  
-Make arguments of constructors *implicit* with curly brackets.
+Underscores can be hidden by making arguments of constructors *implicit* with
+curly brackets.
 
 \begin{code}
 data Fin : ℕ → Set where
@@ -50,14 +50,14 @@ data Fin : ℕ → Set where
   suc  : {n : _} → Fin n → Fin (suc n)
 \end{code}
 
-After this we have
+After that, we obtain the following:
 
 \begin{code}
 x′ : Fin 3
-x′ = suc {_} (zero {_}) 
+x′ = suc {_} (zero {_})
 \end{code}
 
-`{_}` can be deleted:
+And the `{_}`s can be now deleted:
 
 \begin{code}
 x″ : Fin 3
@@ -111,15 +111,31 @@ the implicit arguments make the types unique.
 Named and multiple implicit arguments
 ==========
 
-TODO
+There can be more implicit arguments, as the following definition
+demonstrates:
 
+\begin{code}
+data T : ℕ → ℕ → ℕ → Set where
+  c : {n m k : _} → T (suc n) (suc m) (suc k)
 
+xt : T 1 2 3
+xt = c
+\end{code}
 
+In addition to that, in case of multiple implicit arguments, some of their
+actual values may be set by naming them.  For example:
+
+\begin{code}
+xt' : T 1 2 3
+xt' = c {m = 1}
+\end{code}
 
 Syntactic abbreviations
 =======================
 
-~~~~~~~~~~~ 
+Consider the following definitions again from above:
+
+~~~~~~~~~~
 data Fin′ : ℕ → Set where
   zero : (n : _) → Fin′ (suc n)
   suc  : (n : _) → Fin′ n → Fin′ (suc n)
@@ -129,9 +145,10 @@ data Fin : ℕ → Set where
   suc  : {n : _} → Fin n → Fin (suc n)
 ~~~~~~~~~~~
 
-Variables with inferred types can be introduced by `∀`:
+There variables with inferred types can be introduced by the `∀` (universal
+quantification) symbol, no matter if they are explicit or implicit:
 
-~~~~~~~~~~~ 
+~~~~~~~~~~~
 data Fin′ : ℕ → Set where
   zero : ∀ n → Fin′ (suc n)
   suc  : ∀ n → Fin′ n → Fin′ (suc n)
@@ -140,7 +157,3 @@ data Fin : ℕ → Set where
   zero : ∀ {n} → Fin (suc n)
   suc  : ∀ {n} → Fin n → Fin (suc n)
 ~~~~~~~~~~~
-
-
-
-


### PR DESCRIPTION
Here are the pack of changes that were made during the introductory Agda course at ELTE.  It only covers the first part of the curriculum as we have only reached the section on Sigma.  Those changes are mostly about style and grammar fixes (at least I hope so) and add some more text about certain topics.  Though, I have also had to shuffle the exercises around to create some unified format.  But it requires some further hacking around Pandoc and PandocAgda make them look nice (and highlighted) as before.
